### PR TITLE
fix linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,6 +105,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Update packages
+        run: sudo apt-get update && sudo apt-get upgrade -y
+
       - name: Checkout sources
         uses: actions/checkout@v6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Update packages
-        run: sudo apt-get update && sudo apt-get upgrade -y
+        run: sudo apt-get update && sudo apt-get install --only-upgrade rustc
 
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Update packages
-        run: sudo apt-get update && sudo apt-get install --only-upgrade rustc
+      - name: Update rustup
+        run: rustup update
 
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Update rustup
+        run: rustup update
+
       - name: Checkout sources
         uses: actions/checkout@v6
 
@@ -52,6 +55,9 @@ jobs:
       name: Lint Translations
       runs-on: ubuntu-24.04
       steps:
+        - name: Update rustup
+          run: rustup update
+
         - name: Checkout sources
           uses: actions/checkout@v6
 


### PR DESCRIPTION
fixes linting by running `rustup update` before every other step for all lint jobs

I could also add the command for *all* workflows if you want, but this at least fixes the backend lint not working