### PR TITLE
fix save button not work by ui in option to EmailSmtp form

### DIFF
--- a/frontend/src/pages/admin/settings/forms/EmailSmtp.tsx
+++ b/frontend/src/pages/admin/settings/forms/EmailSmtp.tsx
@@ -21,6 +21,7 @@ export default function EmailSmtp({ form }: { form: UseFormReturnType<z.infer<ty
       username: form.values.username ?? null,
       password: form.values.password ?? null,
       tlsMode: form.values.tlsMode ?? 'start_tls',
+      skipCertValidation: form.values.skipCertValidation ?? false,
       fromAddress: form.values.fromAddress ?? '',
       fromName: form.values.fromName ?? null,
     });


### PR DESCRIPTION
fix this error and save button not work because Mantine need string to detect user fill all input to enable save button
<img width="1156" height="583" alt="image" src="https://github.com/user-attachments/assets/583366a9-a250-48e8-aa03-210ea71d9a32" />
