### PR TITLE
i18n: complete French (fr) translation

### DIFF
--- a/frontend/public/translations/fr.json
+++ b/frontend/public/translations/fr.json
@@ -31,6 +31,62 @@
       "few": "{count} Clés SSH",
       "many": "{count} Clés SSH",
       "other": "{count} Clés SSH"
+    },
+    "byte": {
+      "zero": "{count} Octets",
+      "one": "{count} Octet",
+      "two": "{count} Octets",
+      "few": "{count} Octets",
+      "many": "{count} Octets",
+      "other": "{count} Octets"
+    },
+    "node": {
+      "zero": "{count} Nœuds",
+      "one": "{count} Nœud",
+      "two": "{count} Nœuds",
+      "few": "{count} Nœuds",
+      "many": "{count} Nœuds",
+      "other": "{count} Nœuds"
+    },
+    "allocation": {
+      "zero": "{count} Allocations de nœud",
+      "one": "{count} Allocation de nœud",
+      "two": "{count} Allocations de nœud",
+      "few": "{count} Allocations de nœud",
+      "many": "{count} Allocations de nœud",
+      "other": "{count} Allocations de nœud"
+    },
+    "shortcut": {
+      "zero": "{count} Raccourcis",
+      "one": "{count} Raccourci",
+      "two": "{count} Raccourcis",
+      "few": "{count} Raccourcis",
+      "many": "{count} Raccourcis",
+      "other": "{count} Raccourcis"
+    },
+    "line": {
+      "zero": "{count} Lignes",
+      "one": "{count} Ligne",
+      "two": "{count} Lignes",
+      "few": "{count} Lignes",
+      "many": "{count} Lignes",
+      "other": "{count} Lignes"
+    },
+    "asset": {
+      "zero": "{count} Assets",
+      "one": "{count} Asset",
+      "two": "{count} Assets",
+      "few": "{count} Assets",
+      "many": "{count} Assets",
+      "other": "{count} Assets"
+    },
+    "egg": {
+      "zero": "{count} Eggs",
+      "one": "{count} Egg",
+      "two": "{count} Eggs",
+      "few": "{count} Eggs",
+      "many": "{count} Eggs",
+      "other": "{count} Eggs"
     }
   },
   "translations": {
@@ -53,21 +109,42 @@
         "back": "Retour",
         "next": "Suivant",
         "install": "Installer",
-        "selectAll": "Sélectionner Tout",
-        "deselectAll": "Désélectionner Tout",
+        "selectAll": "Sélectionner tout",
+        "deselectAll": "Désélectionner tout",
         "download": "Télécharger",
         "downloadAs": "Télécharger en {format}",
         "import": "Importer",
         "details": "Détails",
-        "setPrimary": "Définir primaire",
-        "unsetPrimary": "Retirer primarité",
-        "leavePage": "Quitter la page"
+        "setPrimary": "Définir comme primaire",
+        "unsetPrimary": "Retirer le statut primaire",
+        "leavePage": "Quitter la page",
+        "okay": "D'accord",
+        "restore": "Restaurer",
+        "discard": "Abandonner",
+        "export": "Exporter",
+        "exportAs": "Exporter en {format}",
+        "recreate": "Recréer",
+        "move": "Déplacer",
+        "transfer": "Transférer",
+        "reattach": "Rattacher",
+        "detach": "Détacher",
+        "send": "Envoyer",
+        "reset": "Réinitialiser",
+        "view": "Voir",
+        "loadLogs": "Charger les journaux",
+        "sendTestEmail": "Envoyer un e-mail de test",
+        "viewDocumentation": "Voir la documentation"
       },
       "input": {
         "search": "Chercher..."
       },
       "tooltip": {
-        "primary": "Primaire"
+        "primary": "Primaire",
+        "resetToDefault": "Réinitialiser à la valeur par défaut",
+        "edit": "Modifier",
+        "delete": "Supprimer",
+        "remove": "Retirer",
+        "backupOnDifferentNode": "Cette sauvegarde se trouve sur un nœud différent de celui du serveur. Elle n'est pas consultable depuis l'API client."
       },
       "form": {
         "name": "Nom",
@@ -103,7 +180,52 @@
         "authenticationCode": "Code d'authentification",
         "ignoredFiles": "Fichiers ignorés",
         "yourControlPanelPassword": "Votre mot de passe de panel de contrôle",
-        "truncateDirectory": "Souhaitez-vous supprimer tous les fichiers de ce serveur avant d'effectuer cette action ? Ceci n'est pas réversible."
+        "truncateDirectory": "Souhaitez-vous supprimer tous les fichiers de ce serveur avant d'effectuer cette action ? Ceci n'est pas réversible.",
+        "author": "Auteur",
+        "type": "Type",
+        "usernameOrEmail": "Nom d'utilisateur/Adresse e-mail",
+        "path": "Chemin",
+        "provider": "Fournisseur",
+        "command": "Commande",
+        "fromAddress": "Adresse d'expéditeur",
+        "fromName": "Nom d'expéditeur",
+        "siteKey": "Clé de site",
+        "secretKey": "Clé secrète",
+        "apiKey": "Clé API",
+        "accessKey": "Clé d'accès",
+        "bucket": "Bucket",
+        "region": "Région",
+        "endpoint": "Point de terminaison",
+        "publicUrl": "URL publique",
+        "identifier": "Identifiant",
+        "title": "Titre",
+        "content": "Contenu",
+        "backupConfiguration": "Configuration de sauvegarde",
+        "archiveFormat": "Format d'archive",
+        "compressionLevel": "Niveau de compression",
+        "multiplexChannels": "Canaux de multiplexage",
+        "multiplexChannelsDescription": "Ajoute des connexions HTTP supplémentaires (et donc des threads) pour transférer les archives fractionnées ; le nombre total de flux est de 1 + canaux de multiplexage.",
+        "deleteSourceBackups": "Supprimer les sauvegardes source",
+        "deleteSourceBackupsDescription": "Supprime les sauvegardes transférées sur le nœud source une fois le transfert terminé.",
+        "node": "Nœud",
+        "primaryAllocation": "Allocation primaire",
+        "additionalAllocations": "Allocations supplémentaires",
+        "externalId": "ID externe",
+        "mount": "Montage",
+        "nest": "Nest",
+        "lines": "Lignes",
+        "timezoneSystem": "Système",
+        "powerAction": "Action d'alimentation",
+        "portRanges": "Plages de ports",
+        "portRangesPlaceholder": "Plages de ports (ex. 3000-4000)",
+        "restoreStartup": "Restaurer la commande de démarrage, l'image et les variables depuis cette sauvegarde.",
+        "lineContains": "La ligne contient",
+        "filePath": "Chemin du fichier",
+        "envVariable": "Variable d'environnement",
+        "value": "Valeur",
+        "eggs": "Eggs",
+        "deploymentEnabled": "Déploiement activé",
+        "maintenanceEnabled": "Maintenance activée"
       },
       "table": {
         "pagination": {
@@ -122,7 +244,27 @@
           "ip": "IP",
           "when": "Quand",
           "command": "Commande",
-          "notes": "Notes"
+          "notes": "Notes",
+          "id": "ID",
+          "author": "Auteur",
+          "type": "Type",
+          "title": "Titre",
+          "enabled": "Activé",
+          "updated": "Mis à jour",
+          "location": "Emplacement",
+          "node": "Nœud",
+          "owner": "Propriétaire",
+          "added": "Ajouté",
+          "backupConfiguration": "Configuration de sauvegarde",
+          "status": "Statut",
+          "allocation": "Allocation",
+          "source": "Source",
+          "target": "Cible",
+          "checksum": "Somme de contrôle",
+          "files": "Fichiers",
+          "server": "Serveur",
+          "address": "Adresse",
+          "eggs": "Eggs"
         }
       },
       "server": {
@@ -130,7 +272,10 @@
         "state": {
           "suspended": "Suspendu",
           "restoringBackup": "Restauration de la sauvegarde",
-          "installing": "Installation"
+          "installing": "Installation",
+          "transferring": "Le serveur est en cours de transfert",
+          "nodeMaintenance": "Le nœud est en maintenance",
+          "installFailed": "Échec de l'installation"
         }
       },
       "enum": {
@@ -145,7 +290,7 @@
         "serverState": {
           "unknown": "Inconnu",
           "offline": "Hors-ligne",
-          "running": "Allumé",
+          "running": "En marche",
           "starting": "Démarrage",
           "stopping": "Arrêt"
         },
@@ -169,6 +314,17 @@
           "stopped": "Arrêté",
           "restarted": "Redémarré",
           "killed": "Tué"
+        },
+        "serverBackupStatus": {
+          "starting": "Démarrage",
+          "finished": "Terminé",
+          "failed": "Échoué"
+        },
+        "compressionLevel": {
+          "bestSpeed": "Vitesse maximale",
+          "goodSpeed": "Bonne vitesse",
+          "goodCompression": "Bonne compression",
+          "bestCompression": "Compression maximale"
         }
       },
       "unlimited": "Illimité",
@@ -180,6 +336,42 @@
       "api": "API",
       "system": "Système",
       "schedule": "Planification",
+      "custom": "Personnalisé",
+      "default": "Par défaut",
+      "never": "Jamais",
+      "none": "Aucun",
+      "unknown": "Inconnu",
+      "alert": {
+        "error": "Erreur",
+        "warning": "Avertissement",
+        "success": "Succès",
+        "clockOffset": "L'horloge de votre système est désynchronisée de plus de 5 secondes par rapport au serveur. Cela peut causer des problèmes avec l'authentification par clé d'accès et l'authentification à deux facteurs. Veuillez synchroniser votre horloge si des problèmes surviennent. Décalage actuel : {offset} seconde(s)."
+      },
+      "badge": {
+        "active": "Actif",
+        "inactive": "Inactif",
+        "enabled": "Activé",
+        "disabled": "Désactivé",
+        "successful": "Réussi",
+        "failed": "Échoué",
+        "installed": "Installé"
+      },
+      "divider": {
+        "or": "OU"
+      },
+      "tabs": {
+        "general": "Général"
+      },
+      "unit": {
+        "bytes": {
+          "bytes": "o",
+          "kibibytes": "Kio",
+          "mebibytes": "Mio",
+          "gibibytes": "Gio",
+          "tebibytes": "Tio",
+          "pebibytes": "Pio"
+        }
+      },
       "impersonatedBy": "Usurpé par {username}"
     },
     "elements": {
@@ -200,16 +392,25 @@
       },
       "container": {
         "alert": {
-          "impersonating": "Vous usurpez un utilisateur. Vos actions peuvent affecter le compte de la personne usurpée. Pour quitter le mode usurpation, cliquez le bouton \"Arrêter l'usurpation\" dans le coin bas gauche."
+          "impersonating": "Vous usurpez un utilisateur. Vos actions peuvent affecter le compte de la personne usurpée. Pour quitter le mode usurpation, cliquez sur le bouton \"Arrêter l'usurpation\" dans le coin bas gauche."
         }
       },
       "sidebar": {
         "button": {
           "logout": "Se déconnecter",
-          "stopImpersonating": "Arrêter l'usurpation"
+          "stopImpersonating": "Arrêter l'usurpation",
+          "openInVirtualWindow": "Ouvrir dans une fenêtre virtuelle",
+          "openInPopup": "Ouvrir dans une fenêtre contextuelle",
+          "openInNewTab": "Ouvrir dans un nouvel onglet",
+          "switchToDark": "Passer en mode sombre",
+          "switchToLight": "Passer en mode clair"
         }
       },
       "permissionSelector": {
+        "button": {
+          "copyPermissions": "Copier les permissions",
+          "pastePermissions": "Coller les permissions"
+        },
         "selectedPermissions": "Permissions sélectionnées ({count})",
         "noPermissions": "Pas de permissions sélectionnées."
       },
@@ -225,9 +426,2283 @@
             "title": "Détails de l'activité"
           }
         }
+      },
+      "selectInput": {
+        "noResults": "Aucun résultat trouvé."
+      },
+      "pasteOnClick": {
+        "toast": {
+          "pasted": "Collé depuis le presse-papier.",
+          "failed": "Échec du collage depuis le presse-papier.",
+          "pasteManual": "Coller depuis le presse-papier : Ctrl+V ou Command+V, Entrée"
+        }
+      },
+      "resource": {
+        "tooltip": {
+          "created": "{resource} créé.",
+          "updated": "{resource} mis à jour.",
+          "deleted": "{resource} supprimé."
+        }
+      },
+      "estimatedTimeArrival": {
+        "tooltip": {
+          "estimating": "Estimation du temps de fin...",
+          "estimated": "Temps de fin estimé : {time}"
+        },
+        "calculating": "ETA : Calcul en cours...",
+        "calculated": "ETA : {time}"
+      },
+      "fileUpload": {
+        "toast": {
+          "uploading": "Téléversement de {files} démarré...",
+          "cancelledFile": "Téléversement de `{file}` annulé avec succès.",
+          "cancelledFolder": "Téléversement de `{folder}` ({files}) annulé avec succès.",
+          "cancelledAll": "Tous les téléversements ont été annulés."
+        }
+      },
+      "routeOrderEditor": {
+        "title": "Configuration des routes",
+        "label": {
+          "route": "Route",
+          "divider": "Séparateur",
+          "redirect": "Redirection"
+        },
+        "empty": "Aucune route configurée. Ajoutez des routes, des séparateurs ou des redirections ci-dessous.",
+        "unnamed": "(sans nom)",
+        "dividerPlaceholder": "Libellé du séparateur (optionnel)",
+        "redirectNamePlaceholder": "Nom de la redirection",
+        "destinationPlaceholder": "URL de destination (ex. https://...)",
+        "selectRoutePlaceholder": "Sélectionner une route…",
+        "button": {
+          "addDivider": "Ajouter un séparateur",
+          "addRedirect": "Ajouter une redirection"
+        }
+      },
+      "scheduleDynamicInput": {
+        "enterVariable": "Veuillez entrer le nom de la variable à évaluer.",
+        "enterData": "Veuillez entrer les données à envoyer.",
+        "inputType": "Type d'entrée",
+        "dataType": "Type de données à envoyer",
+        "selectType": "Sélectionner le type",
+        "none": "Aucun",
+        "rawString": "Chaîne brute",
+        "variable": "Variable"
+      },
+      "screenBlock": {
+        "permissionDenied": {
+          "title": "Permission refusée",
+          "content": "Vous n'avez pas la permission d'accéder à cette page."
+        },
+        "notFound": {
+          "title": "Introuvable",
+          "content": "La page que vous recherchez est introuvable."
+        },
+        "suspended": {
+          "title": "Compte suspendu",
+          "content": "Votre compte a été suspendu. Vous ne pouvez pas apporter de modifications à votre compte. Veuillez contacter un administrateur pour plus d'informations."
+        },
+        "serverConflict": {
+          "title": "État du serveur en conflit",
+          "contentSuspended": "Ce serveur est suspendu et n'est pas accessible.",
+          "contentNodeMaintenance": "Ce serveur est sur un nœud actuellement en maintenance et n'est pas accessible.",
+          "contentTransferring": "Ce serveur est en cours de transfert et ne sera pas accessible tant que le transfert n'est pas terminé.",
+          "contentInstallFailed": "L'installation de ce serveur a échoué et il n'est pas accessible tant qu'elle n'est pas acquittée.",
+          "contentInstalling": "Ce serveur est en cours d'installation et ne sera pas accessible tant qu'elle n'est pas terminée.",
+          "contentRestoringBackup": "Ce serveur est en cours de restauration depuis une sauvegarde et ne sera pas accessible tant qu'elle n'est pas terminée.",
+          "button": {
+            "viewInstallLogs": "Voir les journaux d'installation",
+            "acknowledgeFailure": "Acquitter l'échec"
+          },
+          "modal": {
+            "acknowledgeFailure": {
+              "title": "Acquitter l'échec d'installation",
+              "content": "En acquittant cet échec d'installation, vous confirmez que vous êtes au courant de l'échec et que vous avez pris les mesures nécessaires pour résoudre le problème. Cela vous permettra de reprendre le contrôle du serveur."
+            }
+          }
+        }
+      },
+      "serverWebsocket": {
+        "error": {
+          "connectionFailed": "Impossible de se connecter après plusieurs tentatives. Veuillez actualiser la page.",
+          "connectionClosed": "La connexion au serveur a été fermée. Tentative de reconnexion...",
+          "connectionRetry": "Connexion perdue. Nouvelle tentative (tentative {attempt})...",
+          "authFailed": "Échec de l'authentification. Tentative d'actualisation des identifiants... ({error})",
+          "authRefreshFailed": "Échec de l'actualisation des identifiants. Veuillez actualiser la page pour réessayer.",
+          "permissionRevoked": "Connexion fermée : votre accès à ce serveur a été révoqué.",
+          "tokenRefreshLoop": "Boucle d'authentification détectée. Veuillez actualiser la page pour réessayer."
+        },
+        "banner": {
+          "retrying": "Nouvelle tentative dans {countdown}..."
+        },
+        "listener": {
+          "toast": {
+            "backupCompleted": "Sauvegarde terminée avec succès.",
+            "backupFailed": "Échec de la sauvegarde.",
+            "backupRestoreCompleted": "Restauration de la sauvegarde terminée avec succès.",
+            "installCompleted": "Installation du serveur terminée avec succès.",
+            "installFailed": "Échec de l'installation du serveur.",
+            "operations": {
+              "compressing": {
+                "completed": "{files} compressés vers `{path}` en {time}.",
+                "failed": "Échec de la compression de {files} vers `{path}` :\n{error}"
+              },
+              "decompressing": {
+                "completed": "`{path}` décompressé vers `{destination}` en {time}.",
+                "failed": "Échec de la décompression de `{path}` vers `{destination}` :\n{error}"
+              },
+              "pulling": {
+                "completed": "`{destination}` récupéré en {time}.",
+                "failed": "Échec de la récupération de `{destination}` :\n{error}"
+              },
+              "copying": {
+                "completed": "`{path}` copié vers `{destination}` en {time}.",
+                "failed": "Échec de la copie de `{path}` vers `{destination}` :\n{error}"
+              },
+              "copyingMany": {
+                "completed": "{files} copiés en {time}.",
+                "failed": "Échec de la copie de {files} :\n{error}"
+              },
+              "copyingRemote": {
+                "completedFrom": "{files} copiés depuis le serveur distant en {time}.",
+                "completedTo": "{files} copiés vers le serveur distant en {time}.",
+                "failedFrom": "Échec de la copie de {files} depuis le serveur distant :\n{error}",
+                "failedTo": "Échec de la copie de {files} vers le serveur distant :\n{error}"
+              }
+            }
+          }
+        }
       }
     },
     "pages": {
+      "admin": {
+        "home": {
+          "title": "Accueil",
+          "alert": {
+            "newPanelVersion": "Une nouvelle version du panel est disponible ! Vous êtes actuellement sur {current} et la dernière version est {latest}. Vous devriez envisager une mise à niveau. [Cliquez ici]({upgradeUrl}) pour voir les instructions de mise à niveau."
+          },
+          "tabs": {
+            "overview": {
+              "title": "Vue d'ensemble",
+              "page": {
+                "permissionDenied": "Vous n'avez pas la permission de lire les statistiques qui auraient dû s'afficher ici. En attendant, profitez de cet oiseau.",
+                "card": {
+                  "systemOverview": "Vue d'ensemble du système",
+                  "generalStatistics": "Statistiques générales",
+                  "backupStatistics": "Statistiques des sauvegardes"
+                },
+                "system": {
+                  "cpu": "CPU",
+                  "memoryUsage": "Utilisation de la mémoire ({process} utilisé par le panel)",
+                  "memoryValue": "{used} / {total} ({percent}%)",
+                  "kernelVersion": "Version du noyau ({architecture})",
+                  "containerType": "Type de conteneur",
+                  "databaseVersion": "Version de la base de données ({size})",
+                  "cacheVersion": "Version du cache",
+                  "cacheCalls": "Appels au cache",
+                  "cacheHits": "Succès du cache ({percent}%)",
+                  "cacheMisses": "Échecs du cache ({percent}%)",
+                  "avgCachedCallLatency": "Latence moyenne des appels en cache"
+                },
+                "containerType": {
+                  "none": "Aucun détecté",
+                  "official": "Officiel",
+                  "officialAio": "Officiel AIO",
+                  "officialHeavy": "Officiel Heavy"
+                },
+                "stats": {
+                  "users": "Utilisateurs",
+                  "servers": "Serveurs",
+                  "locations": "Emplacements",
+                  "nodes": "Nœuds",
+                  "nestEggs": "Eggs de Nest",
+                  "databaseHosts": "Hôtes de base de données",
+                  "backupConfigurations": "Configurations de sauvegarde",
+                  "roles": "Rôles"
+                },
+                "backup": {
+                  "allTime": "Depuis toujours",
+                  "today": "Aujourd'hui",
+                  "week": "Cette semaine",
+                  "month": "Ce mois-ci",
+                  "totalAllTime": "Total des sauvegardes depuis toujours",
+                  "successfulAllTime": "Sauvegardes réussies depuis toujours",
+                  "failedAllTime": "Sauvegardes échouées depuis toujours",
+                  "deletedAllTime": "Sauvegardes supprimées depuis toujours",
+                  "totalToday": "Total des sauvegardes aujourd'hui",
+                  "successfulToday": "Sauvegardes réussies aujourd'hui",
+                  "failedToday": "Sauvegardes échouées aujourd'hui",
+                  "deletedToday": "Sauvegardes supprimées aujourd'hui",
+                  "totalWeek": "Total des sauvegardes cette semaine",
+                  "successfulWeek": "Sauvegardes réussies cette semaine",
+                  "failedWeek": "Sauvegardes échouées cette semaine",
+                  "deletedWeek": "Sauvegardes supprimées cette semaine",
+                  "totalMonth": "Total des sauvegardes ce mois-ci",
+                  "successfulMonth": "Sauvegardes réussies ce mois-ci",
+                  "failedMonth": "Sauvegardes échouées ce mois-ci",
+                  "deletedMonth": "Sauvegardes supprimées ce mois-ci",
+                  "successfulValue": "{count} ({size})",
+                  "deletedValue": "{count} ({size})"
+                }
+              }
+            },
+            "updates": {
+              "title": "Mises à jour",
+              "page": {
+                "alert": {
+                  "extensionUpdateErrors": "Des erreurs sont survenues lors de la vérification des mises à jour de certaines extensions."
+                },
+                "card": {
+                  "panelVersion": "Version du panel",
+                  "versionHistory": "Historique des versions",
+                  "outdatedExtensions": "Extensions obsolètes",
+                  "outdatedNodes": "Nœuds obsolètes"
+                },
+                "panelVersion": "Votre panel utilise actuellement la version `{current}`. La dernière version disponible est `{latest}`.",
+                "unknown": "inconnu",
+                "button": {
+                  "recheck": "Revérifier les mises à jour"
+                },
+                "toast": {
+                  "recheckComplete": "Revérification terminée."
+                },
+                "selectHistory": "Sélectionnez un historique de mises à jour à consulter.",
+                "historyPanel": "Panel",
+                "historyExtension": "Extension : {name}",
+                "extensionsUpToDate": "Toutes les extensions sont à jour.",
+                "extensionsOutdated": "Certaines extensions sont obsolètes ou ont rencontré des erreurs lors de la vérification des mises à jour.",
+                "noChangelog": "Aucun journal des modifications",
+                "nodesUpToDate": "Il semble que tous les nœuds soient à jour. ({failed} échec(s) de vérification)",
+                "nodesOutdated": "Certains nœuds sont obsolètes, la dernière version disponible est `{latest}`. ({outdated} obsolète(s), {failed} échec(s) de vérification)",
+                "table": {
+                  "version": "Version",
+                  "installed": "Installée",
+                  "packageName": "Nom du paquet",
+                  "latestVersion": "Dernière version",
+                  "changes": "Modifications",
+                  "error": "Erreur"
+                }
+              }
+            },
+            "health": {
+              "title": "Santé",
+              "page": {
+                "card": {
+                  "generalHealth": "Santé générale",
+                  "extensionMigrationHealth": "Santé des migrations d'extensions",
+                  "desyncNodes": "Nœuds désynchronisés",
+                  "debugMode": "Mode débogage"
+                },
+                "appliedMigrations": "Migrations appliquées ({percent}%)",
+                "migrationsValue": "{applied} / {total}",
+                "avgNtpOffset": "Décalage NTP moyen",
+                "noExtensions": "Aucune extension trouvée.",
+                "nodesSynced": "Il semble que tous les nœuds aient une horloge synchronisée (à moins de 5 secondes de l'horloge du panel). ({failed} échec(s) de vérification)",
+                "nodesDesync": "Certains nœuds ont une horloge désynchronisée (à plus de 5 secondes de l'horloge du panel). Cela peut causer des problèmes de téléchargement de fichiers/console. ({desync} désynchronisé(s), {failed} échec(s) de vérification)",
+                "debugEnabled": "Le mode débogage est actuellement activé.",
+                "debugDisabled": "Le mode débogage est actuellement désactivé.",
+                "debugResetNote": "Ce paramètre sera réinitialisé à sa valeur par défaut ({default}) au redémarrage de l'application.",
+                "table": {
+                  "packageName": "Nom du paquet",
+                  "applied": "Appliquées",
+                  "total": "Total",
+                  "id": "ID",
+                  "desync": "Désync",
+                  "appliedValue": "{applied} ({percent}%)"
+                },
+                "button": {
+                  "enableDebug": "Activer le mode débogage",
+                  "disableDebug": "Désactiver le mode débogage"
+                },
+                "toast": {
+                  "debugEnabled": "Mode débogage activé.",
+                  "debugDisabled": "Mode débogage désactivé."
+                }
+              }
+            }
+          }
+        },
+        "settings": {
+          "title": "Paramètres",
+          "tabs": {
+            "application": {
+              "title": "Application",
+              "page": {
+                "title": "Paramètres de l'application",
+                "form": {
+                  "icon": "Icône",
+                  "iconLight": "Icône (mode clair)",
+                  "banner": "Bannière",
+                  "bannerLight": "Bannière (mode clair)",
+                  "sessionCookie": "Cookie de session",
+                  "sessionDurationSeconds": "Durée de session (secondes)",
+                  "twoFactorRequirement": "Exigence d'authentification à deux facteurs",
+                  "telemetryEnabled": "Activer la télémétrie",
+                  "telemetryEnabledDescription": "Autoriser Calagopus à collecter des données d'utilisation limitées et anonymes pour aider à améliorer l'application.",
+                  "registrationEnabled": "Activer l'inscription"
+                },
+                "enum": {
+                  "twoFactorRequirement": {
+                    "admins": "Administrateurs",
+                    "allUsers": "Tous les utilisateurs",
+                    "none": "Aucun"
+                  }
+                },
+                "button": {
+                  "previewTelemetry": "Aperçu de la télémétrie"
+                },
+                "toast": {
+                  "updated": "Paramètres de l'application mis à jour."
+                },
+                "modal": {
+                  "disableTelemetry": {
+                    "title": "Confirmer la désactivation de la télémétrie",
+                    "content": "Êtes-vous sûr de vouloir désactiver la télémétrie ? La télémétrie nous aide à améliorer Calagopus en fournissant des données d'utilisation anonymes. La désactiver empêchera l'envoi de toute donnée."
+                  },
+                  "enableRegistration": {
+                    "title": "Confirmer l'activation de l'inscription",
+                    "content": "Êtes-vous sûr de vouloir activer l'inscription ? L'activer permet à n'importe qui de créer un compte sur ce panel. Si vous n'avez pas de captcha configuré, cela peut être une erreur."
+                  },
+                  "telemetryPreview": {
+                    "title": "Aperçu de la télémétrie"
+                  }
+                }
+              }
+            },
+            "storage": {
+              "title": "Stockage",
+              "page": {
+                "title": "Paramètres de stockage",
+                "form": {
+                  "driver": "Pilote"
+                },
+                "enum": {
+                  "driver": {
+                    "filesystem": "Système de fichiers",
+                    "s3": "S3"
+                  }
+                },
+                "toast": {
+                  "updated": "Paramètres de stockage mis à jour."
+                },
+                "modal": {
+                  "changeStorageType": {
+                    "title": "Confirmer le changement de type de stockage",
+                    "content": "Êtes-vous sûr de vouloir changer le type de stockage ? Ce changement amènera l'application à chercher les assets (ex. photos de profil) à un autre emplacement, ce qui peut entraîner des assets manquants s'ils ne sont pas déplacés manuellement vers le nouvel emplacement."
+                  }
+                },
+                "s3": {
+                  "alert": {
+                    "permissionsTitle": "Note sur les permissions",
+                    "permissionsIntro": "Pour que le backend de stockage fonctionne correctement, veuillez vous assurer que les sous-répertoires suivants sont accessibles publiquement via l'« URL publique » que vous avez fournie :",
+                    "permissionsAssets": "C'est ici que tous les assets d'administration (ex. icônes) seront stockés.",
+                    "permissionsAvatars": "C'est ici que tous les avatars des utilisateurs seront stockés.",
+                    "permissionsPublicData": "C'est ici que les extensions peuvent stocker des données publiques (ex. images)."
+                  },
+                  "form": {
+                    "pathStyle": "Utiliser des URL de style chemin"
+                  }
+                }
+              }
+            },
+            "mail": {
+              "title": "E-mail",
+              "page": {
+                "title": "Paramètres e-mail",
+                "enum": {
+                  "provider": {
+                    "none": "Aucun",
+                    "smtp": "SMTP",
+                    "sendmail": "Commande Sendmail",
+                    "filesystem": "Système de fichiers"
+                  },
+                  "tlsMode": {
+                    "none": "Aucun",
+                    "startTls": "STARTTLS",
+                    "implicitTls": "TLS implicite"
+                  }
+                },
+                "toast": {
+                  "updated": "Paramètres e-mail mis à jour."
+                },
+                "modal": {
+                  "sendTestEmail": {
+                    "title": "Envoyer un e-mail de test",
+                    "toast": {
+                      "sent": "L'e-mail de test a été envoyé avec succès."
+                    }
+                  }
+                },
+                "smtp": {
+                  "form": {
+                    "tlsMode": "Mode TLS",
+                    "skipCertValidation": "Ignorer la validation du certificat"
+                  }
+                }
+              }
+            },
+            "mailTemplates": {
+              "title": "Modèles d'e-mail",
+              "page": {
+                "title": "Paramètres des modèles d'e-mail",
+                "sidebar": {
+                  "templates": "Modèles",
+                  "loading": "Chargement...",
+                  "availableVariables": "Variables disponibles"
+                },
+                "alert": {
+                  "syntaxBefore": "Les modèles utilisent la",
+                  "syntaxLink": "MiniJinja",
+                  "syntaxMiddle": "syntaxe de templating. Les variables sont référencées avec",
+                  "syntaxAnd": "et les structures de contrôle comme",
+                  "syntaxOr": "et",
+                  "syntaxAfter": "sont prises en charge."
+                },
+                "empty": "Sélectionnez un modèle dans la barre latérale pour le modifier.",
+                "loadingTemplate": "Chargement du modèle...",
+                "form": {
+                  "subject": "Objet"
+                },
+                "toast": {
+                  "saved": "Modèle d'e-mail enregistré.",
+                  "reset": "Modèle d'e-mail réinitialisé par défaut."
+                },
+                "modal": {
+                  "reset": {
+                    "title": "Réinitialiser par défaut",
+                    "content": "Ceci abandonnera votre modèle personnalisé pour **{identifier}** et restaurera le modèle par défaut intégré. Cette action est irréversible."
+                  }
+                }
+              }
+            },
+            "captcha": {
+              "title": "Captcha",
+              "page": {
+                "title": "Paramètres du captcha",
+                "toast": {
+                  "updated": "Paramètres du captcha mis à jour."
+                },
+                "recaptcha": {
+                  "form": {
+                    "v3": "V3"
+                  }
+                }
+              }
+            },
+            "webauthn": {
+              "title": "Webauthn",
+              "page": {
+                "title": "Paramètres Webauthn",
+                "form": {
+                  "rpId": "RP Id",
+                  "rpOrigin": "RP Origin"
+                },
+                "button": {
+                  "autofill": "Remplissage automatique"
+                },
+                "toast": {
+                  "updated": "Paramètres Webauthn mis à jour.",
+                  "ipNotAllowed": "Impossible d'utiliser WebAuthn sur une adresse IP."
+                },
+                "modal": {
+                  "changeRpId": {
+                    "title": "Confirmer le changement de RP Id",
+                    "content": "Êtes-vous sûr de vouloir changer le RP Id ? Changer le RP Id cassera tous les identifiants Webauthn existants et obligera les utilisateurs à réenregistrer leurs appareils. Cela peut avoir des conséquences importantes, alors assurez-vous de bien comprendre les implications avant de continuer."
+                  }
+                }
+              }
+            },
+            "server": {
+              "title": "Serveur",
+              "page": {
+                "title": "Paramètres serveur",
+                "form": {
+                  "maxFileManagerViewSize": "Taille max. d'affichage du gestionnaire de fichiers",
+                  "maxScheduleStepCount": "Étapes de planification max.",
+                  "maxFileManagerContentSearchSize": "Taille max. de recherche de contenu du gestionnaire de fichiers",
+                  "maxFileManagerSearchResults": "Résultats de recherche max. du gestionnaire de fichiers",
+                  "maxSubuserCount": "Nombre max. de sous-utilisateurs",
+                  "allowOverwritingCustomDockerImage": "Autoriser l'écrasement de l'image Docker personnalisée",
+                  "allowOverwritingCustomDockerImageDescription": "Si activé, les utilisateurs pourront écraser l'image Docker spécifiée dans la configuration du serveur via la liste des Eggs, même si un administrateur a défini une image Docker personnalisée.",
+                  "allowViewingInstallationLogs": "Autoriser la consultation des journaux d'installation",
+                  "allowViewingInstallationLogsDescription": "Si activé, les utilisateurs ayant la permission de lecture de la console pourront aussi consulter les journaux d'installation via la connexion websocket. Si désactivé, les journaux d'installation ne seront disponibles que pour les administrateurs.",
+                  "allowAcknowledgingInstallationFailure": "Autoriser l'acquittement des échecs d'installation",
+                  "allowAcknowledgingInstallationFailureDescription": "Si activé, les utilisateurs pourront acquitter les échecs d'installation des serveurs dans l'état « Échec de l'installation », ce qui leur permet de tenter de démarrer le serveur au lieu d'attendre un administrateur. Si désactivé, seuls les administrateurs pourront acquitter les échecs d'installation.",
+                  "allowViewingTransferProgress": "Autoriser la consultation de la progression du transfert",
+                  "allowViewingTransferProgressDescription": "Si activé, les utilisateurs ayant la permission de lecture de la console pourront aussi consulter les journaux de progression du transfert via la connexion websocket. Si désactivé, les journaux de progression du transfert ne seront disponibles que pour les administrateurs.",
+                  "containerPrelude": "Prélude du conteneur",
+                  "containerPreludeDescription": "Le prélude de terminal utilisé pour certains messages liés au statut dans la console du serveur."
+                },
+                "toast": {
+                  "updated": "Paramètres serveur mis à jour."
+                }
+              }
+            },
+            "user": {
+              "title": "Utilisateur",
+              "page": {
+                "title": "Paramètres utilisateur",
+                "form": {
+                  "maxServerGroupCount": "Nombre max. de groupes de serveurs",
+                  "maxApiKeyCount": "Nombre max. de clés API",
+                  "maxCommandSnippetCount": "Nombre max. d'extraits de commande",
+                  "maxSecurityKeyCount": "Nombre max. de clés de sécurité",
+                  "maxSshKeyCount": "Nombre max. de clés SSH",
+                  "allowChangingLanguage": "Autoriser le changement de langue",
+                  "allowChangingLanguageDescription": "Si activé, les utilisateurs pourront modifier leurs préférences de langue."
+                },
+                "routeOrder": {
+                  "title": "Ordre des routes client"
+                },
+                "toast": {
+                  "updated": "Paramètres utilisateur mis à jour."
+                }
+              }
+            },
+            "activity": {
+              "title": "Activité",
+              "page": {
+                "title": "Paramètres d'activité",
+                "form": {
+                  "adminLogRetentionDays": "Jours de rétention de l'activité admin",
+                  "userLogRetentionDays": "Jours de rétention de l'activité utilisateur",
+                  "serverLogRetentionDays": "Jours de rétention de l'activité serveur",
+                  "adminLogRetentionCount": "Nombre de rétention de l'activité admin",
+                  "userLogRetentionCount": "Nombre de rétention de l'activité utilisateur",
+                  "serverLogRetentionCount": "Nombre de rétention de l'activité serveur",
+                  "serverLogAdminActivity": "Journaliser l'activité admin sur les serveurs",
+                  "serverLogAdminActivityDescription": "Activer ou désactiver la journalisation de l'activité admin sur les serveurs où l'administrateur n'est ni propriétaire ni sous-utilisateur.",
+                  "serverLogScheduleActivity": "Journaliser l'activité des planifications du serveur",
+                  "serverLogScheduleActivityDescription": "Activer ou désactiver la journalisation de l'activité effectuée par les planifications du serveur."
+                },
+                "toast": {
+                  "updated": "Paramètres d'activité mis à jour."
+                }
+              }
+            },
+            "ratelimits": {
+              "title": "Limites de débit",
+              "page": {
+                "title": "Paramètres des limites de débit",
+                "form": {
+                  "hits": "Requêtes",
+                  "hitsDescription": "Nombre maximal de requêtes autorisées par fenêtre.",
+                  "windowSeconds": "Fenêtre",
+                  "windowSecondsDescription": "Durée de la fenêtre en secondes."
+                },
+                "toast": {
+                  "updated": "Paramètres des limites de débit mis à jour."
+                }
+              }
+            }
+          }
+        },
+        "announcements": {
+          "title": "Annonces",
+          "resourceName": "Annonce",
+          "tabs": {
+            "general": {
+              "page": {
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression de l'annonce",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{title}** ?"
+                  }
+                },
+                "form": {
+                  "dismissibleEnd": "Fin de masquage",
+                  "enabledStart": "Début d'activation",
+                  "enabledEnd": "Fin d'activation",
+                  "locations": "Emplacements",
+                  "locationsDescription": "Laissez vide pour appliquer à tous les emplacements.",
+                  "nodes": "Nœuds",
+                  "nodesDescription": "Laissez vide pour appliquer à tous les nœuds.",
+                  "backupConfigurations": "Configurations de sauvegarde",
+                  "backupConfigurationsDescription": "Laissez vide pour appliquer à toutes les configurations de sauvegarde.",
+                  "eggsPlaceholder": "Sélectionner des Eggs",
+                  "dismissible": "Masquable"
+                },
+                "titleCreate": "Créer une annonce",
+                "titleUpdate": "Modifier l'annonce"
+              }
+            }
+          },
+          "enum": {
+            "announcementType": {
+              "info": "Info",
+              "success": "Succès",
+              "warning": "Avertissement",
+              "error": "Erreur"
+            }
+          }
+        },
+        "assets": {
+          "title": "Assets",
+          "button": {
+            "newDirectory": "Nouveau répertoire",
+            "upload": "Téléverser",
+            "copyLink": "Copier le lien"
+          },
+          "dropzone": {
+            "title": "Déposez les fichiers ici pour les téléverser",
+            "subtitle": "Relâchez pour démarrer le téléversement"
+          },
+          "operations": {
+            "waiting": "En attente : ",
+            "uploading": "Téléversement : "
+          },
+          "toast": {
+            "assetDeleted": "Asset supprimé.",
+            "assetsDeleted": "{assets} supprimés."
+          },
+          "modal": {
+            "createDirectory": {
+              "title": "Nouveau répertoire",
+              "createdAs": "Sera créé à "
+            },
+            "deleteAssets": {
+              "title": "Confirmer la suppression des assets",
+              "content": "Êtes-vous sûr de vouloir supprimer `{count}` assets ?"
+            },
+            "deleteAsset": {
+              "title": "Supprimer l'asset",
+              "content": "Êtes-vous sûr de vouloir supprimer cet asset ? Cette action est irréversible."
+            }
+          }
+        },
+        "locations": {
+          "title": "Emplacements",
+          "resourceName": "Emplacement",
+          "tabs": {
+            "general": {
+              "page": {
+                "form": {
+                  "flag": "Drapeau"
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression de l'emplacement",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                },
+                "titleCreate": "Créer un emplacement",
+                "titleUpdate": "Modifier l'emplacement"
+              }
+            },
+            "databaseHosts": {
+              "title": "Hôtes de base de données",
+              "page": {
+                "title": "Hôtes de base de données de l'emplacement",
+                "toast": {
+                  "created": "Hôte de base de données de l'emplacement créé.",
+                  "deleted": "Hôte de base de données de l'emplacement supprimé."
+                },
+                "modal": {
+                  "create": {
+                    "title": "Créer un hôte de base de données d'emplacement"
+                  },
+                  "delete": {
+                    "title": "Confirmer la suppression de l'hôte de base de données de l'emplacement",
+                    "content": "Êtes-vous sûr de vouloir supprimer l'hôte de base de données **{name}** de **{location}** ?"
+                  }
+                }
+              }
+            },
+            "nodes": {
+              "title": "Nœuds",
+              "page": {
+                "title": "Nœuds de l'emplacement"
+              }
+            }
+          }
+        },
+        "databaseHosts": {
+          "title": "Hôtes de base de données",
+          "resourceName": "Hôte de base de données",
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un hôte de base de données",
+                "titleUpdate": "Modifier l'hôte de base de données",
+                "form": {
+                  "publicHost": "Hôte public",
+                  "publicPort": "Port public",
+                  "connectionCredentials": "Identifiants de connexion",
+                  "credentialType": "Type d'identifiant",
+                  "connectionString": "Chaîne de connexion",
+                  "connectionStringPlaceholder": "mysql://username:password@host:port"
+                },
+                "enum": {
+                  "credentialType": {
+                    "connectionString": "Chaîne de connexion",
+                    "details": "Détails"
+                  }
+                },
+                "button": {
+                  "testConnection": "Tester la connexion"
+                },
+                "toast": {
+                  "tested": "Test effectué avec succès."
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression de l'hôte de base de données",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                }
+              }
+            },
+            "databases": {
+              "title": "Bases de données",
+              "page": {
+                "title": "Bases de données de l'hôte"
+              }
+            }
+          }
+        },
+        "users": {
+          "title": "Utilisateurs",
+          "resourceName": "Utilisateur",
+          "tooltip": {
+            "admin": "Admin",
+            "twoFactorEnabled": "2FA activé",
+            "twoFactorDisabled": "2FA désactivé"
+          },
+          "table": {
+            "columns": {
+              "role": "Rôle"
+            }
+          },
+          "tabs": {
+            "general": {
+              "page": {
+                "tooltip": {
+                  "cannotImpersonateSelf": "Vous ne pouvez pas vous usurper vous-même."
+                },
+                "button": {
+                  "disableTwoFactor": "Désactiver l'authentification à deux facteurs",
+                  "sendPasswordResetEmail": "Envoyer un e-mail de réinitialisation du mot de passe",
+                  "impersonate": "Usurper"
+                },
+                "form": {
+                  "admin": "Admin",
+                  "adminDescription": "Les utilisateurs admin ont un accès complet et illimité à tout le panel.",
+                  "frozen": "Gelé",
+                  "frozenDescription": "Les utilisateurs gelés ne peuvent apporter aucune modification aux informations de leur compte.",
+                  "suspended": "Suspendu",
+                  "suspendedDescription": "Les utilisateurs suspendus ne peuvent pas accéder au panel de manière significative.",
+                  "role": "Rôle"
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression de l'utilisateur",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{username}** ?"
+                  },
+                  "disableTwoFactor": {
+                    "title": "Désactiver l'authentification à deux facteurs de l'utilisateur",
+                    "content": "Êtes-vous sûr de vouloir retirer l'authentification à deux facteurs de **{username}** ?",
+                    "toast": {
+                      "disabled": "Authentification à deux facteurs de l'utilisateur désactivée."
+                    }
+                  },
+                  "sendPasswordResetEmail": {
+                    "title": "Envoyer un e-mail de réinitialisation du mot de passe",
+                    "content": "Êtes-vous sûr de vouloir envoyer un e-mail de réinitialisation du mot de passe à **{email}** ?",
+                    "toast": {
+                      "sent": "E-mail de réinitialisation du mot de passe envoyé."
+                    }
+                  }
+                },
+                "titleCreate": "Créer un utilisateur",
+                "titleUpdate": "Modifier l'utilisateur"
+              }
+            },
+            "servers": {
+              "title": "Serveurs",
+              "page": {
+                "title": "Serveurs de l'utilisateur",
+                "showOwnedOnly": "Afficher uniquement les serveurs possédés par les utilisateurs"
+              }
+            },
+            "oauthLinks": {
+              "title": "Liens OAuth",
+              "page": {
+                "title": "Liens OAuth de l'utilisateur",
+                "toast": {
+                  "added": "Lien OAuth ajouté.",
+                  "removed": "Lien OAuth supprimé."
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter un lien OAuth",
+                    "form": {
+                      "oauthProvider": "Fournisseur OAuth"
+                    }
+                  },
+                  "delete": {
+                    "title": "Confirmer la suppression du lien OAuth",
+                    "content": "Êtes-vous sûr de vouloir supprimer la connexion **{provider}** de **{username}** ?"
+                  }
+                }
+              }
+            },
+            "activity": {
+              "title": "Activité",
+              "page": {
+                "title": "Activité de l'utilisateur"
+              }
+            }
+          }
+        },
+        "mounts": {
+          "title": "Montages",
+          "resourceName": "Montage",
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un montage",
+                "titleUpdate": "Modifier le montage",
+                "alert": "Les montages sont une fonctionnalité puissante et potentiellement dangereuse. Une mauvaise utilisation peut entraîner une perte de données ou des failles de sécurité (y compris des évasions de conteneur). Assurez-vous de comprendre les implications de l'utilisation des montages avant d'en créer ou d'en modifier.",
+                "form": {
+                  "source": "Source",
+                  "target": "Cible",
+                  "readOnly": "Lecture seule",
+                  "userMountable": "Montable par l'utilisateur"
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression du montage",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                }
+              }
+            },
+            "eggs": {
+              "title": "Eggs",
+              "page": {
+                "title": "Eggs du montage",
+                "toast": {
+                  "added": "Egg du montage ajouté.",
+                  "removed": "Egg du montage supprimé."
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter un Egg au montage",
+                    "form": {
+                      "egg": "Egg"
+                    }
+                  },
+                  "remove": {
+                    "title": "Confirmer le retrait de l'Egg du montage",
+                    "content": "Êtes-vous sûr de vouloir retirer le montage **{mount}** de **{name}** ?"
+                  }
+                }
+              }
+            },
+            "nodes": {
+              "title": "Nœuds",
+              "page": {
+                "title": "Nœuds du montage",
+                "toast": {
+                  "added": "Nœud du montage ajouté.",
+                  "removed": "Nœud du montage supprimé."
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter un nœud au montage"
+                  },
+                  "remove": {
+                    "title": "Confirmer le retrait du nœud du montage",
+                    "content": "Êtes-vous sûr de vouloir retirer le montage **{mount}** de **{name}** ?"
+                  }
+                }
+              }
+            },
+            "servers": {
+              "title": "Serveurs",
+              "page": {
+                "title": "Serveurs du montage"
+              }
+            }
+          }
+        },
+        "eggRepositories": {
+          "title": "Dépôts d'Eggs",
+          "resourceName": "Dépôt d'Eggs",
+          "table": {
+            "columns": {
+              "gitRepository": "Dépôt Git"
+            }
+          },
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un dépôt d'Eggs",
+                "titleUpdate": "Modifier le dépôt d'Eggs",
+                "form": {
+                  "gitRepository": "Dépôt Git"
+                },
+                "button": {
+                  "sync": "Synchroniser"
+                },
+                "toast": {
+                  "synced": "Dépôt d'Eggs synchronisé, {eggs} trouvés."
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression du dépôt d'Eggs",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                }
+              }
+            },
+            "eggs": {
+              "title": "Eggs",
+              "page": {
+                "title": "Eggs du dépôt",
+                "table": {
+                  "columns": {
+                    "path": "Chemin"
+                  }
+                },
+                "toast": {
+                  "installed": "Egg installé.",
+                  "installedBulk": "{eggs} installés."
+                },
+                "modal": {
+                  "install": {
+                    "title": "Installer l'Egg du dépôt"
+                  },
+                  "installBulk": {
+                    "title": "Installer les Eggs du dépôt",
+                    "button": "Installer {eggs}"
+                  }
+                },
+                "drawer": {
+                  "noReadme": "Cet Egg n'a pas de README."
+                }
+              }
+            }
+          }
+        },
+        "extensions": {
+          "title": "Extensions",
+          "unknownExtension": "Extension inconnue",
+          "alert": {
+            "noExtensions": "Aucune extension installée.",
+            "heavyImageMissing": "Il semble que vous n'utilisiez pas l'image heavy requise pour installer des extensions, consultez [ici]({docsUrl}) comment basculer dessus."
+          },
+          "button": {
+            "viewBuildLogs": "Voir les journaux de compilation",
+            "install": "Installer une extension",
+            "rebuild": "Recompiler les extensions",
+            "configure": "Configurer",
+            "back": "Retour aux extensions",
+            "accept": "Accepter",
+            "decline": "Refuser"
+          },
+          "tooltip": {
+            "building": "Le panel est en train de compiler le code des extensions. Veuillez patienter.",
+            "noPendingBuild": "Aucune extension en attente de compilation.",
+            "noBackend": "Une extension backend est requise pour configurer cette extension.",
+            "noConfigurationPage": "Cette extension n'a pas de page de configuration définie.",
+            "removeExtension": "Retirer l'extension"
+          },
+          "badge": {
+            "frontendMissing": "Frontend manquant",
+            "backendMissing": "Backend manquant",
+            "pendingBuild": "Compilation en attente",
+            "pendingRemoval": "Retrait en attente"
+          },
+          "card": {
+            "version": "Version",
+            "authors": "Auteurs"
+          },
+          "section": {
+            "pendingExtensions": "Extensions en attente",
+            "noPendingExtensions": "Aucune extension en attente."
+          },
+          "dropzone": {
+            "title": "Déposez des fichiers ici pour les installer en tant qu'extensions",
+            "subtitle": "Relâchez pour démarrer l'installation"
+          },
+          "toast": {
+            "buildStarted": "Recompilation des extensions démarrée avec succès.",
+            "buildCompleted": "Compilation des extensions terminée. Vous devrez peut-être actualiser la page.",
+            "added": "Extension `{packageName}` ajoutée avec succès.",
+            "removed": "Extension `{packageName}` supprimée avec succès."
+          },
+          "notFound": {
+            "title": "Extension introuvable",
+            "content": "Extension avec le nom de paquet « {packageName} » introuvable."
+          },
+          "configure": {
+            "title": "Configurer {packageName}",
+            "noConfigurationPage": "Cette extension n'a pas de page de configuration."
+          },
+          "modal": {
+            "buildLogs": {
+              "title": "Journaux de compilation",
+              "empty": "Aucun journal trouvé."
+            },
+            "license": {
+              "title": "Accord de licence",
+              "description": "L'extension `{packageName}` requiert que vous acceptiez la licence suivante avant de pouvoir être installée."
+            },
+            "remove": {
+              "title": "Retirer l'extension",
+              "content": "Êtes-vous sûr de vouloir retirer l'extension `{packageName}` ? Cette action est irréversible.",
+              "form": {
+                "removeMigrations": "Voulez-vous supprimer et annuler les migrations de base de données de cette extension ?"
+              }
+            }
+          }
+        },
+        "eggConfigurations": {
+          "title": "Configurations d'Eggs",
+          "resourceName": "Configuration d'Egg",
+          "table": {
+            "columns": {
+              "order": "Ordre"
+            }
+          },
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer une configuration d'Egg",
+                "titleUpdate": "Modifier la configuration d'Egg",
+                "form": {
+                  "order": "Ordre",
+                  "eggs": "Eggs",
+                  "eggsPlaceholder": "Sélectionner des Eggs"
+                },
+                "enum": {
+                  "deploymentType": {
+                    "random": "Aléatoire",
+                    "range": "Plage de ports",
+                    "addPrimary": "Ajouter au primaire",
+                    "subtractPrimary": "Soustraire du primaire",
+                    "multiplyPrimary": "Multiplier le primaire",
+                    "dividePrimary": "Diviser le primaire"
+                  }
+                },
+                "allocation": {
+                  "title": "Configuration d'allocation",
+                  "form": {
+                    "userSelfAssign": "Auto-attribution par l'utilisateur",
+                    "userSelfAssignDescription": "Autoriser les utilisateurs à créer leurs propres allocations à partir d'une plage de ports spécifiée.",
+                    "requirePrimaryAllocation": "Exiger une allocation primaire",
+                    "requirePrimaryAllocationDescription": "Indique si les utilisateurs doivent toujours avoir une allocation primaire.",
+                    "automaticAllocationStart": "Début d'allocation automatique",
+                    "automaticAllocationEnd": "Fin d'allocation automatique",
+                    "dedicatedIp": "IP dédiée",
+                    "dedicatedIpDescription": "Attribuer une adresse IP dédiée aux serveurs utilisant cette configuration d'Egg.",
+                    "primaryAllocation": "Allocation primaire",
+                    "primaryAllocationDescription": "Configurer une attribution de port primaire pour le déploiement.",
+                    "primaryStartPort": "Port de début primaire",
+                    "primaryEndPort": "Port de fin primaire",
+                    "assignToVariable": "Attribuer à une variable",
+                    "assignToVariablePlaceholder": "ex. SERVER_PORT",
+                    "assignToVariableDescription": "Variable d'environnement optionnelle qui recevra le port primaire attribué."
+                  },
+                  "divider": {
+                    "deployment": "Déploiement"
+                  },
+                  "additionalPorts": {
+                    "title": "Ports supplémentaires",
+                    "button": "Ajouter une règle",
+                    "empty": "Aucune règle de port supplémentaire configurée."
+                  },
+                  "deployment": {
+                    "form": {
+                      "startPort": "Port de début",
+                      "endPort": "Port de fin",
+                      "assignToVariable": "Attribuer à une variable",
+                      "assignToVariableDescription": "Variable d'environnement optionnelle qui recevra le port attribué par cette règle.",
+                      "assignToVariablePlaceholder": "ex. SERVER_PORT"
+                    },
+                    "removeRule": "Retirer la règle de déploiement"
+                  }
+                },
+                "startup": {
+                  "title": "Configuration de démarrage",
+                  "form": {
+                    "allowCustomStartupCommand": "Autoriser une commande de démarrage personnalisée",
+                    "allowCustomStartupCommandDescription": "Autoriser les utilisateurs à définir leurs propres commandes de démarrage non prédéfinies."
+                  }
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression de la configuration d'Egg",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "oAuthProviders": {
+          "title": "Fournisseurs OAuth",
+          "resourceName": "Fournisseur OAuth",
+          "dropzone": {
+            "title": "Déposez des fichiers ici pour les importer en tant que fournisseurs OAuth",
+            "subtitle": "Relâchez pour démarrer l'importation"
+          },
+          "table": {
+            "columns": {
+              "loginOnly": "Connexion uniquement",
+              "linkViewable": "Lien visible",
+              "userManageable": "Gérable par l'utilisateur"
+            }
+          },
+          "toast": {
+            "imported": "Fournisseur OAuth importé.",
+            "parseFailed": "Échec de l'analyse du fournisseur OAuth : {error}"
+          },
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un fournisseur OAuth",
+                "titleUpdate": "Modifier le fournisseur OAuth",
+                "card": {
+                  "redirectUrl": {
+                    "title": "URL de redirection",
+                    "unavailable": "Disponible après la création"
+                  }
+                },
+                "form": {
+                  "clientId": "Client Id",
+                  "clientSecret": "Client Secret",
+                  "authUrl": "URL d'authentification",
+                  "tokenUrl": "URL de token",
+                  "infoUrl": "URL d'info",
+                  "basicAuth": "Authentification basique",
+                  "basicAuthDescription": "Utilise l'authentification HTTP Basic pour transmettre le client id et le secret, peu courant désormais.",
+                  "scopes": "Scopes",
+                  "scopesDescription": "Les scopes OAuth2 à demander, veillez à inclure les scopes pour l'e-mail et les informations de profil si nécessaire.",
+                  "identifierPath": "Chemin de l'identifiant",
+                  "identifierPathDescription": "Le chemin utilisé pour extraire l'identifiant unique de l'utilisateur depuis la réponse de l'URL d'info (https://serdejsonpath.live).",
+                  "emailPath": "Chemin de l'e-mail",
+                  "emailPathDescription": "Le chemin utilisé pour extraire l'e-mail depuis la réponse de l'URL d'info (https://serdejsonpath.live).",
+                  "usernamePath": "Chemin du nom d'utilisateur",
+                  "usernamePathDescription": "Le chemin utilisé pour extraire le nom d'utilisateur depuis la réponse de l'URL d'info (https://serdejsonpath.live).",
+                  "nameFirstPath": "Chemin du prénom",
+                  "nameFirstPathPlaceholder": "URL du prénom",
+                  "nameFirstPathDescription": "Le chemin utilisé pour extraire le prénom depuis la réponse de l'URL d'info (https://serdejsonpath.live).",
+                  "nameLastPath": "Chemin du nom de famille",
+                  "nameLastPathDescription": "Le chemin utilisé pour extraire le nom de famille depuis la réponse de l'URL d'info (https://serdejsonpath.live).",
+                  "loginOnly": "Autoriser uniquement la connexion",
+                  "loginBypass2fa": "Contourner la 2FA à la connexion",
+                  "loginBypass2faDescription": "Permet aux utilisateurs se connectant avec ce fournisseur de contourner leur 2FA du panel.",
+                  "linkViewable": "Lien visible par l'utilisateur",
+                  "linkViewableDescription": "Permet à l'utilisateur de voir la connexion et son identifiant dans l'interface client.",
+                  "userManageable": "Lien gérable par l'utilisateur",
+                  "userManageableDescription": "Permet à l'utilisateur de se connecter et se déconnecter avec ce fournisseur."
+                },
+                "toast": {
+                  "exported": "Fournisseur OAuth exporté."
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression du fournisseur OAuth",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                }
+              }
+            },
+            "mappings": {
+              "title": "Mappages",
+              "page": {
+                "title": "Mappages du fournisseur OAuth",
+                "table": {
+                  "columns": {
+                    "scopes": "Scopes"
+                  }
+                },
+                "enum": {
+                  "mappingType": {
+                    "role": "Rôle",
+                    "serverSubuser": "Sous-utilisateur de serveur"
+                  }
+                },
+                "toast": {
+                  "created": "Mappage du fournisseur OAuth créé.",
+                  "updated": "Mappage du fournisseur OAuth mis à jour.",
+                  "deleted": "Mappage du fournisseur OAuth supprimé."
+                },
+                "form": {
+                  "scopes": "Scopes",
+                  "scopesDescription": "Scopes OAuth requis pour que ce mappage s'applique.",
+                  "mappingType": "Type de mappage",
+                  "role": "Rôle",
+                  "permissions": "Permissions"
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter un mappage de fournisseur OAuth"
+                  },
+                  "edit": {
+                    "title": "Modifier le mappage de fournisseur OAuth"
+                  },
+                  "delete": {
+                    "title": "Supprimer le mappage de fournisseur OAuth",
+                    "content": "Êtes-vous sûr de vouloir supprimer ce mappage ? Cette action est irréversible."
+                  }
+                }
+              }
+            },
+            "users": {
+              "title": "Utilisateurs",
+              "page": {
+                "title": "Utilisateurs du fournisseur OAuth",
+                "table": {
+                  "columns": {
+                    "user": "Utilisateur"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "backupConfigurations": {
+          "title": "Configurations de sauvegarde",
+          "resourceName": "Configuration de sauvegarde",
+          "table": {
+            "columns": {
+              "disk": "Disque"
+            }
+          },
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer une configuration de sauvegarde",
+                "titleUpdate": "Modifier la configuration de sauvegarde",
+                "alert": {
+                  "ddupBak": "Ddup-Bak est un logiciel en avant-première technologique, il n'est techniquement pas recommandé pour une utilisation en production. Si vous l'acceptez, allez-y comme bon vous semble.",
+                  "btrfs": "Btrfs nécessite une configuration supplémentaire sur le nœud pour fonctionner, veuillez [consulter la documentation]({docsUrl}) pour plus de détails.",
+                  "zfs": "ZFS nécessite une configuration supplémentaire sur le nœud pour fonctionner, veuillez [consulter la documentation]({docsUrl}) pour plus de détails.",
+                  "pbs": "Le token d'API fourni nécessite les ACL de datastore suivantes : **DatastoreAudit** pour l'utilisation et le listage, **DatastoreBackup** pour l'écriture des sauvegardes, et **DatastoreAdmin** (ou des permissions équivalentes d'élagage/suppression) si la suppression ou l'élagage des sauvegardes est activé."
+                },
+                "form": {
+                  "backupDisk": "Disque de sauvegarde",
+                  "maintenanceEnabledDescription": "Si activé, tout serveur utilisant cette configuration de sauvegarde ne pourra pas créer de nouvelles sauvegardes ni gérer les existantes.",
+                  "shared": "Partagé",
+                  "sharedDescription": "Si activé, les sauvegardes de cette configuration ne seront pas transférées entre les nœuds ; elles seront supposées accessibles par tous les nœuds."
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression de la configuration de sauvegarde",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                },
+                "s3": {
+                  "title": "Paramètres S3",
+                  "form": {
+                    "partSize": "Taille de partie",
+                    "compressionType": "Type de compression",
+                    "pathStyle": "Utiliser des URL de style chemin"
+                  }
+                },
+                "restic": {
+                  "title": "Paramètres Restic",
+                  "form": {
+                    "repository": "Dépôt",
+                    "retryLockSeconds": "Secondes de réessai du verrou",
+                    "environmentVariables": "Variables d'environnement",
+                    "cronSchedule": "Planification Cron",
+                    "cronScheduleDescription": "Format : seconde minute heure jour mois jour-de-semaine.",
+                    "nodes": "Nœuds",
+                    "nodesPlaceholder": "Sélectionner des nœuds"
+                  },
+                  "pruneJobs": {
+                    "title": "Tâches d'élagage",
+                    "description": "Exécutions d'élagage Restic planifiées. Chaque tâche s'exécute sur les nœuds configurés selon sa planification cron.",
+                    "button": {
+                      "add": "Ajouter une tâche d'élagage"
+                    }
+                  }
+                },
+                "pbs": {
+                  "title": "Paramètres Proxmox Backup Server",
+                  "form": {
+                    "url": "URL du serveur",
+                    "datastore": "Datastore",
+                    "namespace": "Namespace",
+                    "tokenId": "ID du token",
+                    "tokenSecret": "Secret du token",
+                    "fingerprint": "Empreinte du certificat TLS",
+                    "backupIdPrefix": "Préfixe d'ID de sauvegarde"
+                  }
+                },
+                "kopia": {
+                  "title": "Paramètres Kopia",
+                  "form": {
+                    "url": "URL du serveur Kopia",
+                    "fingerprint": "Empreinte du certificat TLS",
+                    "tags": "Tags de sauvegarde"
+                  }
+                }
+              }
+            },
+            "stats": {
+              "title": "Statistiques",
+              "page": {
+                "title": "Statistiques de la configuration de sauvegarde",
+                "card": {
+                  "title": "Statistiques des sauvegardes"
+                },
+                "period": {
+                  "allTime": "Depuis toujours",
+                  "today": "Aujourd'hui",
+                  "week": "Cette semaine",
+                  "month": "Ce mois-ci"
+                },
+                "periodLabel": {
+                  "allTime": "depuis toujours",
+                  "today": "aujourd'hui",
+                  "week": "cette semaine",
+                  "month": "ce mois-ci"
+                },
+                "stat": {
+                  "total": "Total des sauvegardes {period}",
+                  "successful": "Sauvegardes réussies {period}",
+                  "failed": "Sauvegardes échouées {period}",
+                  "deleted": "Sauvegardes supprimées {period}"
+                }
+              }
+            },
+            "backups": {
+              "title": "Sauvegardes",
+              "page": {
+                "title": "Sauvegardes de la configuration de sauvegarde",
+                "toast": {
+                  "downloadStarted": "Téléchargement commencé."
+                }
+              }
+            },
+            "locations": {
+              "title": "Emplacements",
+              "page": {
+                "title": "Emplacements de la configuration de sauvegarde"
+              }
+            },
+            "nodes": {
+              "title": "Nœuds",
+              "page": {
+                "title": "Nœuds de la configuration de sauvegarde"
+              }
+            },
+            "servers": {
+              "title": "Serveurs",
+              "page": {
+                "title": "Serveurs de la configuration de sauvegarde"
+              }
+            }
+          }
+        },
+        "nests": {
+          "title": "Nests",
+          "resourceName": "Nest",
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un Nest",
+                "titleUpdate": "Modifier le Nest",
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression du Nest",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?",
+                    "form": {
+                      "deleteEggs": "Voulez-vous supprimer tous les Eggs de ce Nest ?"
+                    }
+                  }
+                }
+              }
+            },
+            "eggs": {
+              "title": "Eggs",
+              "page": {
+                "title": "Eggs",
+                "resourceName": "Egg",
+                "dropzone": {
+                  "title": "Déposez des fichiers ici pour les importer en tant qu'Eggs",
+                  "subtitle": "Relâchez pour démarrer l'importation"
+                },
+                "button": {
+                  "updateFromRepository": "Mettre à jour depuis le dépôt"
+                },
+                "toast": {
+                  "imported": "Egg importé.",
+                  "moved": "Egg déplacé.",
+                  "movedBulk": "{eggs} déplacés.",
+                  "deletedBulk": "{eggs} supprimés.",
+                  "updatedFromRepository": "{eggs} mis à jour avec succès à partir de leur Egg de dépôt respectif.",
+                  "parseFailed": "Échec de l'analyse de l'Egg : {error}"
+                },
+                "modal": {
+                  "move": {
+                    "title": "Déplacer l'Egg"
+                  },
+                  "moveBulk": {
+                    "title": "Déplacer les Eggs",
+                    "confirm": "Déplacer {eggs}"
+                  },
+                  "deleteBulk": {
+                    "title": "Confirmer la suppression des Eggs",
+                    "content": "Êtes-vous sûr de vouloir supprimer `{count}` Eggs ?"
+                  }
+                },
+                "tabs": {
+                  "general": {
+                    "page": {
+                      "titleCreate": "Créer un Egg",
+                      "titleUpdate": "Modifier l'Egg",
+                      "card": {
+                        "startupConfiguration": "Configuration de démarrage",
+                        "stopConfiguration": "Configuration d'arrêt",
+                        "configFiles": "Configuration des fichiers de configuration"
+                      },
+                      "form": {
+                        "eggRepository": "Dépôt d'Eggs",
+                        "eggRepositoryEgg": "Egg du dépôt",
+                        "startupDone": "Démarrage terminé",
+                        "startupDoneDescription": "Message de console indiquant la fin du démarrage.",
+                        "stripAnsi": "Retirer l'ANSI des messages de démarrage",
+                        "stripAnsiDescription": "Supprime les caractères de contrôle ANSI de la sortie console avant de détecter la fin du démarrage.",
+                        "stopType": "Type d'arrêt",
+                        "stopCommand": "Commande d'arrêt",
+                        "stopSignal": "Signal d'arrêt",
+                        "parser": "Parseur",
+                        "createNewFile": "Créer un nouveau fichier",
+                        "createNewFileDescription": "Si activé, le fichier sera créé s'il n'existe pas. Si désactivé, le fichier doit déjà exister, sinon le remplacement échouera.",
+                        "match": "Correspondance",
+                        "ifValue": "Si valeur",
+                        "replaceWith": "Remplacer par",
+                        "insertNew": "Insérer nouveau",
+                        "insertNewDescription": "Si activé, lorsqu'aucune valeur existante ne correspond au champ « Correspondance », la valeur « Remplacer par » sera insérée dans le fichier. Si désactivé, en l'absence de correspondance, aucune modification ne sera apportée au fichier.",
+                        "updateExisting": "Mettre à jour l'existant",
+                        "updateExistingDescription": "Si activé, lorsqu'une correspondance est trouvée, elle sera remplacée par la valeur « Remplacer par ». Si désactivé, le remplacement n'insérera que de nouvelles valeurs et échouera si une correspondance est trouvée.",
+                        "startupCommands": "Commandes de démarrage",
+                        "forceOutgoingIp": "Forcer l'IP sortante",
+                        "separatePort": "Séparer l'IP et le port",
+                        "separatePortDescription": "Sépare l'IP et le port primaires sur la page Console au lieu de les joindre avec « : ».",
+                        "features": "Fonctionnalités",
+                        "featurePlaceholder": "Fonctionnalité",
+                        "fileDenylist": "Liste de fichiers interdits",
+                        "dockerImages": "Images Docker"
+                      },
+                      "enum": {
+                        "stopType": {
+                          "command": "Envoyer une commande",
+                          "signal": "Envoyer un signal",
+                          "docker": "Arrêt Docker"
+                        }
+                      },
+                      "emptyConfigFiles": "Aucun fichier de configuration défini.",
+                      "emptyReplacements": "Aucun remplacement défini.",
+                      "button": {
+                        "addReplacement": "Ajouter un remplacement",
+                        "addConfigFile": "Ajouter un fichier de configuration",
+                        "fromFile": "depuis un fichier",
+                        "fromRepository": "depuis le dépôt"
+                      },
+                      "toast": {
+                        "exported": "Egg exporté.",
+                        "updated": "Egg mis à jour."
+                      },
+                      "modal": {
+                        "delete": {
+                          "title": "Confirmer la suppression de l'Egg",
+                          "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                        }
+                      }
+                    }
+                  },
+                  "installationScript": {
+                    "title": "Script d'installation",
+                    "page": {
+                      "title": "Script d'installation de l'Egg",
+                      "form": {
+                        "container": "Conteneur d'installation",
+                        "entrypoint": "Point d'entrée du conteneur"
+                      },
+                      "toast": {
+                        "updated": "Script de l'Egg mis à jour."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "title": "Variables",
+                    "page": {
+                      "title": "Variables de l'Egg",
+                      "form": {
+                        "supportsMarkdown": "Prend en charge le formatage Markdown.",
+                        "defaultValue": "Valeur par défaut",
+                        "defaultValuePlaceholder": "server.jar",
+                        "userViewable": "Visible par l'utilisateur",
+                        "userEditable": "Modifiable par l'utilisateur",
+                        "secret": "Secret",
+                        "rules": "Règles",
+                        "rulesDescription": "Voir https://laravel.com/docs/12.x/validation#available-validation-rules pour les règles de validation disponibles."
+                      },
+                      "toast": {
+                        "created": "Variable de l'Egg créée.",
+                        "updated": "Variable de l'Egg mise à jour.",
+                        "deleted": "Variable de l'Egg supprimée."
+                      },
+                      "modal": {
+                        "delete": {
+                          "title": "Confirmer le retrait de la variable de l'Egg",
+                          "content": "Êtes-vous sûr de vouloir retirer **{variable}** ?",
+                          "emptyVariable": "cette variable vide"
+                        }
+                      }
+                    }
+                  },
+                  "mounts": {
+                    "title": "Montages",
+                    "page": {
+                      "title": "Montages de l'Egg",
+                      "toast": {
+                        "added": "Montage de l'Egg ajouté.",
+                        "deleted": "Montage de l'Egg supprimé."
+                      },
+                      "modal": {
+                        "add": {
+                          "title": "Ajouter un montage à l'Egg"
+                        },
+                        "delete": {
+                          "title": "Confirmer le retrait du montage de l'Egg",
+                          "content": "Êtes-vous sûr de vouloir retirer le montage **{mount}** de **{egg}** ?"
+                        }
+                      }
+                    }
+                  },
+                  "servers": {
+                    "title": "Serveurs",
+                    "page": {
+                      "title": "Serveurs de l'Egg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nodes": {
+          "title": "Nœuds",
+          "resourceName": "Nœud",
+          "tabs": {
+            "general": {
+              "page": {
+                "tooltip": {
+                  "deploymentEnabled": "Déploiement activé",
+                  "deploymentDisabled": "Déploiement désactivé",
+                  "allInOneNode": "Nœud tout-en-un",
+                  "errorWhileFetchingVersion": "Erreur lors de la récupération de la version",
+                  "updateAvailable": "{version} (Mise à jour disponible)",
+                  "useWingsProxyUrl": "Utiliser l'URL proxy de Wings"
+                },
+                "form": {
+                  "urlDescription": "Utilisé pour la communication interne avec le nœud.",
+                  "publicUrlDescription": "Utilisé pour les connexions websocket et les téléchargements.",
+                  "backupConfigurationPlaceholder": "Hériter de l'emplacement"
+                },
+                "button": {
+                  "resetToken": "Réinitialiser le token",
+                  "updateConfig": "Mettre à jour la configuration"
+                },
+                "toast": {
+                  "tokenReset": "Token du nœud réinitialisé."
+                },
+                "alert": {
+                  "noLocations": "Vous devez créer au moins un emplacement avant de pouvoir créer des nœuds. Les emplacements aident à organiser vos nœuds géographiquement ou logiquement."
+                },
+                "titleCreate": "Créer un nœud",
+                "titleUpdate": "Modifier le nœud"
+              }
+            },
+            "configuration": {
+              "title": "Configuration",
+              "page": {
+                "title": "Configuration",
+                "section": {
+                  "initialSetup": "Configuration initiale",
+                  "liveConfiguration": "Configuration en direct"
+                },
+                "description": {
+                  "placeFile": "Placez ceci dans le fichier de configuration à `/etc/pterodactyl/config.yml` ou exécutez"
+                },
+                "tooltip": {
+                  "copyCommand": "Copier la commande"
+                },
+                "form": {
+                  "panelUrl": "URL du panel",
+                  "apiPort": "Port de l'API"
+                },
+                "button": {
+                  "save": "Enregistrer la configuration"
+                },
+                "alert": {
+                  "couldNotReach": "Impossible de joindre le nœud : {error}"
+                },
+                "toast": {
+                  "applied": "Configuration appliquée avec succès.",
+                  "submittedNotApplied": "La configuration a été soumise mais pas appliquée.",
+                  "invalidYaml": "YAML invalide : {error}"
+                }
+              }
+            },
+            "statistics": {
+              "title": "Statistiques",
+              "page": {
+                "title": "Statistiques du nœud",
+                "card": {
+                  "resources": "Ressources",
+                  "graphs": "Graphiques"
+                },
+                "toast": {
+                  "connectionLost": "Connexion au flux de statistiques du nœud perdue."
+                },
+                "label": {
+                  "cpu": "CPU",
+                  "memory": "Mémoire",
+                  "disk": "Disque",
+                  "network": "Réseau",
+                  "cpuThreads": "{model} ({threads} threads)",
+                  "usedByWings": "{size} utilisé par Wings",
+                  "networkIn": "Entrée : {in}",
+                  "networkOut": "Sortie : {out}"
+                },
+                "chart": {
+                  "cpuLoad": "Charge CPU",
+                  "memoryUsage": "Utilisation de la mémoire",
+                  "diskIo": "E/S disque",
+                  "networkTraffic": "Trafic réseau",
+                  "diskRead": "Lecture disque",
+                  "diskWrite": "Écriture disque",
+                  "inbound": "Entrant",
+                  "outbound": "Sortant",
+                  "networkInLabel": "Réseau entrant",
+                  "networkOutLabel": "Réseau sortant"
+                }
+              }
+            },
+            "capacity": {
+              "title": "Capacité",
+              "page": {
+                "title": "Capacité de déploiement",
+                "subtitle": "Ressources allouées aux serveurs de ce nœud, mesurées par rapport aux limites configurées dans les paramètres du nœud, et non à la capacité physique de la machine. Le déploiement ne vérifie que la mémoire et le disque.",
+                "card": {
+                  "resources": "Ressources allouées"
+                },
+                "status": {
+                  "deploymentEnabled": "Déploiement activé",
+                  "deploymentDisabled": "Déploiement désactivé",
+                  "maintenanceEnabled": "En maintenance",
+                  "maintenanceDisabled": "Pas en maintenance"
+                },
+                "label": {
+                  "cpu": "CPU",
+                  "memory": "Mémoire",
+                  "disk": "Disque",
+                  "memoryOverhead": "Surcharge mémoire",
+                  "servers": "Serveurs",
+                  "noLimit": "Aucune limite de nœud",
+                  "free": "{size} libre",
+                  "overhead": "+ {size} de surcharge réservée",
+                  "cores": "{cores} cœurs alloués"
+                }
+              }
+            },
+            "logs": {
+              "title": "Journaux",
+              "page": {
+                "title": "Journaux du nœud",
+                "form": {
+                  "logFile": "Fichier journal",
+                  "follow": "Suivre"
+                },
+                "button": {
+                  "download": "Télécharger le journal complet"
+                },
+                "toast": {
+                  "connectionLost": "Connexion au flux de journaux du nœud perdue."
+                }
+              }
+            },
+            "allocations": {
+              "title": "Allocations",
+              "page": {
+                "title": "Allocations du nœud",
+                "tooltip": {
+                  "clearSelection": "Effacer la sélection"
+                },
+                "form": {
+                  "ipAlias": "Alias IP"
+                },
+                "table": {
+                  "columns": {
+                    "ipAlias": "Alias IP"
+                  }
+                },
+                "modal": {
+                  "create": {
+                    "title": "Créer des allocations de nœud",
+                    "button": {
+                      "create": "Créer {count}"
+                    },
+                    "toast": {
+                      "created": "{allocations} créées."
+                    }
+                  },
+                  "update": {
+                    "title": "Modifier les allocations de nœud",
+                    "toast": {
+                      "updated": "{allocations} mises à jour."
+                    }
+                  },
+                  "delete": {
+                    "title": "Confirmer la suppression des allocations de nœud",
+                    "content": "Êtes-vous sûr de vouloir supprimer `{count}` allocations de **{name}** ?",
+                    "toast": {
+                      "deleted": "{allocations} supprimées."
+                    }
+                  }
+                }
+              }
+            },
+            "mounts": {
+              "title": "Montages",
+              "page": {
+                "title": "Montages du nœud",
+                "toast": {
+                  "added": "Montage du nœud ajouté.",
+                  "removed": "Montage du nœud supprimé."
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter un montage au nœud"
+                  },
+                  "remove": {
+                    "title": "Confirmer le retrait du montage du nœud",
+                    "content": "Êtes-vous sûr de vouloir retirer le montage **{mount}** de **{name}** ?"
+                  }
+                }
+              }
+            },
+            "backups": {
+              "title": "Sauvegardes",
+              "page": {
+                "title": "Sauvegardes du nœud",
+                "input": {
+                  "detachedOnly": "Afficher uniquement les sauvegardes détachées"
+                },
+                "tooltip": {
+                  "backupNotOnSameNode": "Cette sauvegarde n'est pas sur le même nœud que le serveur. Elle n'est pas consultable depuis l'API client."
+                },
+                "toast": {
+                  "downloadStarted": "Téléchargement commencé.",
+                  "detached": "Sauvegarde détachée avec succès.",
+                  "reattached": "Sauvegarde rattachée à {name} avec succès.",
+                  "restoring": "Restauration de la sauvegarde vers {name}...",
+                  "deleted": "Sauvegarde du nœud supprimée."
+                },
+                "modal": {
+                  "detach": {
+                    "title": "Confirmer le détachement de la sauvegarde",
+                    "content": "Êtes-vous sûr de vouloir détacher cette sauvegarde de son serveur ? Elle ne sera pas supprimée et pourra être rattachée plus tard."
+                  },
+                  "reattach": {
+                    "title": "Rattacher la sauvegarde du nœud",
+                    "description": "Rattacher une sauvegarde de nœud la liera à un serveur. C'est utile si la sauvegarde est détachée ou si vous voulez la lier à un serveur différent. Notez que ce n'est pas un outil de transfert : à moins que la sauvegarde ne soit considérée comme distante (accessible par plusieurs nœuds), le serveur doit appartenir au même nœud que la sauvegarde."
+                  },
+                  "restore": {
+                    "title": "Restaurer la sauvegarde du nœud",
+                    "form": {
+                      "truncateDirectory": "Voulez-vous vider le système de fichiers de ce serveur avant de restaurer la sauvegarde ?"
+                    }
+                  },
+                  "delete": {
+                    "title": "Confirmer la suppression de la sauvegarde du nœud",
+                    "form": {
+                      "force": "Voulez-vous forcer la suppression de cette sauvegarde de nœud ?"
+                    }
+                  }
+                }
+              }
+            },
+            "servers": {
+              "title": "Serveurs",
+              "page": {
+                "title": "Serveurs du nœud",
+                "modal": {
+                  "transfer": {
+                    "title": "Transférer les serveurs",
+                    "form": {
+                      "allocationMode": "Mode d'allocation",
+                      "transferBackups": "Transférer les sauvegardes",
+                      "transferBackupsDescription": "Indique s'il faut transférer les sauvegardes avec les serveurs."
+                    },
+                    "toast": {
+                      "started": "Transfert de {servers} démarré."
+                    },
+                    "confirm": {
+                      "title": "Confirmer les transferts de serveurs",
+                      "content": "Êtes-vous sûr de vouloir transférer `{count}` serveurs de **{from}** vers **{to}** ? Cette action est irréversible."
+                    },
+                    "enum": {
+                      "allocationMode": {
+                        "none": "Aucun (supprime toutes les allocations, le serveur ne se verra pas attribuer automatiquement de nouvelles allocations sur le nœud de destination)",
+                        "randomPrimary": "Aléatoiriser l'allocation primaire (supprime les allocations supplémentaires)",
+                        "randomAll": "Aléatoiriser toutes les allocations (recommandé pour éviter les problèmes d'incompatibilité avec le nœud de destination)",
+                        "eggConfigDeployment": "Attribuer les allocations selon la configuration de déploiement de l'Egg (fonctionne uniquement si l'Egg a une configuration de déploiement et que le nœud de destination a des allocations compatibles)",
+                        "eggConfigSelfAssignRange": "Auto-attribuer de nouvelles allocations selon la plage de ports de l'Egg (fonctionne uniquement si l'Egg a une plage de ports et que le nœud de destination a des allocations compatibles)"
+                      }
+                    }
+                  },
+                  "powerAction": {
+                    "title": "Confirmer l'action d'alimentation",
+                    "content": "Êtes-vous sûr de vouloir **{action}** {servers} ?"
+                  }
+                }
+              }
+            },
+            "transfers": {
+              "title": "Transferts sortants",
+              "page": {
+                "title": "Transferts du nœud",
+                "table": {
+                  "columns": {
+                    "progress": "Progression",
+                    "archiveRate": "Débit d'archivage",
+                    "networkRate": "Débit réseau"
+                  }
+                }
+              }
+            }
+          },
+          "modal": {
+            "delete": {
+              "title": "Confirmer la suppression du nœud",
+              "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+            },
+            "bulkConfig": {
+              "title": "Mettre à jour la configuration - {nodes}",
+              "button": {
+                "apply": "Appliquer à {nodes}"
+              },
+              "toast": {
+                "applied": "Configuration appliquée à {nodes}."
+              },
+              "error": {
+                "invalidYaml": "YAML invalide : {error}"
+              }
+            }
+          }
+        },
+        "servers": {
+          "title": "Serveurs",
+          "resourceName": "Serveur",
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un serveur",
+                "titleUpdate": "Modifier le serveur",
+                "card": {
+                  "basicInformation": "Informations de base",
+                  "serverAssignment": "Attribution du serveur",
+                  "resourceLimits": "Limites de ressources",
+                  "serverConfiguration": "Configuration du serveur",
+                  "featureLimits": "Limites de fonctionnalités",
+                  "allocations": "Allocations",
+                  "variables": "Variables"
+                },
+                "alert": {
+                  "suspended": "Ce serveur est suspendu.",
+                  "selectEggForVariables": "Veuillez sélectionner un Egg avant de pouvoir configurer les variables."
+                },
+                "badge": {
+                  "serverSuspended": "Serveur suspendu"
+                },
+                "form": {
+                  "serverNamePlaceholder": "Mon serveur de jeu",
+                  "externalIdPlaceholder": "Identifiant externe optionnel",
+                  "descriptionPlaceholder": "Description du serveur",
+                  "owner": "Propriétaire",
+                  "egg": "Egg",
+                  "backupConfigurationPlaceholder": "Hériter du nœud/de l'emplacement",
+                  "cpuLimit": "Limite CPU (%)",
+                  "cpuLimitDescription": "La limite CPU en % que le serveur peut utiliser, 1 thread = 100 %.",
+                  "swap": "Swap",
+                  "swapDescription": "La quantité de swap à donner à ce serveur, -1 ne définira pas de limite.",
+                  "memoryDescription": "La limite de mémoire du conteneur du serveur, 0 ne définira pas de limite.",
+                  "memoryOverhead": "Surcharge mémoire",
+                  "memoryOverheadDescription": "Mémoire cachée qui sera ajoutée au conteneur.",
+                  "diskSpace": "Espace disque",
+                  "diskSpaceDescription": "La limite de disque du serveur. C'est une limite souple sauf si le limiteur de disque est configuré sur Wings.",
+                  "ioWeight": "Poids d'E/S",
+                  "ioWeightDescription": "Le poids d'E/S relatif du conteneur du serveur par rapport aux autres conteneurs, 0-1000. Peut ne pas fonctionner sur tous les systèmes.",
+                  "pinnedCpus": "CPU épinglés",
+                  "pinnedCpusDescription": "Les cœurs CPU (par index, ex. 0, 1, 2) auxquels ce serveur est épinglé. Laissez vide pour autoriser tous les cœurs.",
+                  "dockerImagePlaceholder": "ghcr.io/...",
+                  "predefinedDockerImages": "Images Docker prédéfinies",
+                  "predefinedDockerImagesPlaceholder": "Aucune image prédéfinie sélectionnée",
+                  "timezonePlaceholder": "Europe/Amsterdam",
+                  "startupCommandPlaceholder": "npm start",
+                  "startupCommandCustom": "Personnalisé",
+                  "startOnCompletion": "Démarrer à la fin",
+                  "startOnCompletionDescription": "Démarrer le serveur une fois l'installation terminée.",
+                  "skipInstaller": "Ignorer l'installateur",
+                  "skipInstallerDescription": "Ignorer l'exécution du script d'installation.",
+                  "hugepagesPassthroughEnabled": "Activer le passthrough Hugepages",
+                  "hugepagesPassthroughEnabledDescription": "Activer le passthrough hugepages pour le serveur (monte /dev/hugepages dans le conteneur).",
+                  "kvmPassthroughEnabled": "Activer le passthrough KVM",
+                  "kvmPassthroughEnabledDescription": "Activer le passthrough KVM pour le serveur (permet l'accès à /dev/kvm à l'intérieur du conteneur).",
+                  "allocationsLimit": "Allocations",
+                  "databasesLimit": "Bases de données",
+                  "backupsLimit": "Sauvegardes",
+                  "schedulesLimit": "Planifications"
+                },
+                "modal": {
+                  "confirmNoAllocation": {
+                    "title": "Aucune allocation primaire attribuée",
+                    "content": "Vous créez un serveur sans attribuer d'allocation primaire. Êtes-vous sûr de vouloir continuer ?",
+                    "button": {
+                      "confirm": "Créer quand même"
+                    }
+                  }
+                }
+              }
+            },
+            "allocations": {
+              "title": "Allocations",
+              "page": {
+                "title": "Allocations du serveur",
+                "table": {
+                  "columns": {
+                    "ipAlias": "Alias IP"
+                  }
+                },
+                "form": {
+                  "notesPlaceholder": "Notes"
+                },
+                "toast": {
+                  "updated": "Allocation mise à jour.",
+                  "setPrimary": "Allocation définie comme primaire.",
+                  "unsetPrimary": "Statut primaire de l'allocation retiré.",
+                  "removed": "Allocation supprimée.",
+                  "added": "{count} allocations ajoutées."
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter des allocations au serveur",
+                    "form": {
+                      "allocations": "Allocations"
+                    },
+                    "button": {
+                      "add": "Ajouter {count}"
+                    }
+                  },
+                  "remove": {
+                    "title": "Confirmer le retrait de l'allocation",
+                    "content": "Êtes-vous sûr de vouloir retirer **{allocation}** ?"
+                  }
+                }
+              }
+            },
+            "variables": {
+              "title": "Variables",
+              "page": {
+                "title": "Variables du serveur",
+                "toast": {
+                  "updated": "Variables du serveur mises à jour."
+                }
+              }
+            },
+            "mounts": {
+              "title": "Montages",
+              "page": {
+                "title": "Montages du serveur",
+                "toast": {
+                  "added": "Montage du serveur ajouté.",
+                  "deleted": "Montage du serveur supprimé."
+                },
+                "modal": {
+                  "add": {
+                    "title": "Ajouter un montage au serveur"
+                  },
+                  "remove": {
+                    "title": "Confirmer le retrait du montage du serveur",
+                    "content": "Êtes-vous sûr de vouloir retirer le montage **{mount}** de **{name}** ?"
+                  }
+                }
+              }
+            },
+            "backups": {
+              "title": "Sauvegardes",
+              "page": {
+                "title": "Sauvegardes du serveur",
+                "input": {
+                  "partiallyDetachedOnly": "Afficher uniquement les sauvegardes partiellement détachées"
+                }
+              }
+            },
+            "logs": {
+              "title": "Journaux",
+              "page": {
+                "title": "Journaux du serveur",
+                "form": {
+                  "logType": "Type de journal"
+                },
+                "enum": {
+                  "logType": {
+                    "console": "Console",
+                    "install": "Installation"
+                  }
+                }
+              }
+            },
+            "management": {
+              "title": "Gestion",
+              "page": {
+                "title": "Gestion du serveur",
+                "transfer": {
+                  "title": "Transfert",
+                  "content": "Transférer ce serveur et ses données vers un autre nœud de ce système.",
+                  "toast": {
+                    "started": "Transfert du serveur démarré."
+                  },
+                  "modal": {
+                    "title": "Transfert du serveur",
+                    "form": {
+                      "backupsToTransfer": "Sauvegardes à transférer"
+                    },
+                    "tooltip": {
+                      "aioNotSupported": "Les transferts vers le nœud tout-en-un ne sont pas pris en charge."
+                    },
+                    "confirm": {
+                      "title": "Confirmer le transfert du serveur",
+                      "content": "Êtes-vous sûr de vouloir transférer **{name}** de **{from}** vers **{to}** ?",
+                      "alert": {
+                        "notAllBackupsSelected": "Vous n'avez pas sélectionné toutes les sauvegardes à transférer ; les sauvegardes restantes deviendront partiellement détachées si le transfert se termine avec succès."
+                      }
+                    }
+                  }
+                },
+                "suspend": {
+                  "title": "Suspendre",
+                  "content": "Ceci suspendra le serveur, arrêtera tous les processus en cours et empêchera immédiatement l'utilisateur d'accéder à ses fichiers ou de gérer le serveur via le panel ou l'API.",
+                  "button": "Suspendre",
+                  "toast": {
+                    "suspended": "Serveur suspendu."
+                  },
+                  "modal": {
+                    "title": "Confirmer la suspension du serveur",
+                    "content": "Êtes-vous sûr de vouloir suspendre **{name}** ? Ceci arrêtera le serveur et l'empêchera de démarrer. Tous les processus en cours seront arrêtés et l'utilisateur ne pourra pas accéder à ses fichiers ni gérer le serveur via le panel ou l'API."
+                  }
+                },
+                "unsuspend": {
+                  "title": "Réactiver",
+                  "content": "Ceci réactivera le serveur, lui permettant de redémarrer. L'utilisateur pourra accéder à ses fichiers et gérer le serveur via le panel ou l'API.",
+                  "button": "Réactiver",
+                  "toast": {
+                    "unsuspended": "Serveur réactivé."
+                  },
+                  "modal": {
+                    "title": "Confirmer la réactivation du serveur",
+                    "content": "Êtes-vous sûr de vouloir réactiver **{name}** ? Ceci permettra au serveur de redémarrer. L'utilisateur pourra accéder à ses fichiers et gérer le serveur via le panel ou l'API."
+                  }
+                },
+                "clearState": {
+                  "title": "Effacer l'état",
+                  "content": "Ceci effacera l'état du serveur connu par le panel.",
+                  "button": "Effacer l'état",
+                  "toast": {
+                    "cleared": "État du serveur effacé."
+                  },
+                  "modal": {
+                    "title": "Confirmer l'effacement de l'état du serveur",
+                    "content": "Êtes-vous sûr de vouloir effacer l'état de **{name}** ? Ceci effacera tous les transferts en attente connus et les échecs de statut ; assurez-vous qu'il est sûr de le faire avant de cliquer sans raison."
+                  }
+                },
+                "delete": {
+                  "title": "Supprimer",
+                  "content": "Ceci supprimera le serveur et toutes ses données. Cette action est irréversible.",
+                  "toast": {
+                    "deleted": "Serveur supprimé."
+                  },
+                  "modal": {
+                    "title": "Confirmer la suppression du serveur",
+                    "description": "Vous êtes sur le point de supprimer **{name}**. Êtes-vous sûr ?",
+                    "form": {
+                      "force": "Voulez-vous forcer la suppression de ce serveur ?",
+                      "deleteBackups": "Voulez-vous supprimer les sauvegardes de ce serveur ?",
+                      "confirmServerName": "Confirmer le nom du serveur",
+                      "confirmServerNamePlaceholder": "Nom du serveur"
+                    }
+                  }
+                }
+              }
+            },
+            "viewClient": {
+              "title": "Voir dans l'espace client"
+            }
+          }
+        },
+        "roles": {
+          "title": "Rôles",
+          "resourceName": "Rôle",
+          "table": {
+            "columns": {
+              "serverPermissions": "Permissions serveur",
+              "adminPermissions": "Permissions admin"
+            }
+          },
+          "tabs": {
+            "general": {
+              "page": {
+                "titleCreate": "Créer un rôle",
+                "titleUpdate": "Modifier le rôle",
+                "alert": {
+                  "impersonate": "Ce rôle possède la permission `users.impersonate`, qui permet aux utilisateurs ayant ce rôle d'usurper n'importe quel autre utilisateur, y compris les administrateurs. Soyez prudent lorsque vous attribuez cette permission à des rôles comportant des utilisateurs moins fiables."
+                },
+                "form": {
+                  "requireTwoFactor": "Exiger l'authentification à deux facteurs",
+                  "requireTwoFactorDescription": "Exiger des utilisateurs ayant ce rôle qu'ils utilisent l'authentification à deux facteurs.",
+                  "serverPermissions": "Permissions serveur",
+                  "adminPermissions": "Permissions admin"
+                },
+                "modal": {
+                  "delete": {
+                    "title": "Confirmer la suppression du rôle",
+                    "content": "Êtes-vous sûr de vouloir supprimer **{name}** ?"
+                  }
+                }
+              }
+            },
+            "users": {
+              "title": "Utilisateurs",
+              "page": {
+                "title": "Utilisateurs du rôle"
+              }
+            }
+          }
+        },
+        "activity": {
+          "title": "Activité"
+        }
+      },
+      "auth": {
+        "button": {
+          "login": "Connexion",
+          "loginWith": "Se connecter avec {name}"
+        },
+        "alert": {
+          "urlMismatch": "L'URL de l'application ne correspond pas à l'URL actuelle. Attendu : `{appUrl}`, Actuel : `{currentUrl}`."
+        },
+        "login": {
+          "error": {
+            "usernameRequired": "Veuillez entrer un nom d'utilisateur",
+            "registrationDisabled": "Aucun compte correspondant n'a été trouvé et l'inscription est actuellement désactivée.",
+            "userAlreadyExists": "Un compte avec ce nom d'utilisateur ou cette adresse e-mail existe déjà."
+          },
+          "passkey": {
+            "error": {
+              "notSupported": "Votre navigateur ne prend pas en charge les clés d'accès.",
+              "unexpected": "Une erreur inattendue s'est produite lors de l'utilisation de votre clé d'accès.",
+              "cancelled": "La demande de clé d'accès a été annulée.",
+              "dismissed": "Vous avez ignoré la demande de clé d'accès ou n'avez pas interagi avec elle. La clé utilisée peut aussi ne pas être enregistrée.",
+              "invalidState": "Cette clé d'accès n'est pas disponible ou est déjà enregistrée.",
+              "notSupportedType": "Votre navigateur ou appareil ne prend pas en charge ce type de clé d'accès.",
+              "securityError": "Les clés d'accès ne peuvent être utilisées qu'en HTTPS et avec un domaine valide.",
+              "authenticatorError": "Une erreur s'est produite avec l'authentificateur.",
+              "constraintError": "L'authentificateur n'a pas pu satisfaire les contraintes requises."
+            }
+          },
+          "step": {
+            "username": {
+              "title": "Connexion",
+              "subtitle": "Entrez votre nom d'utilisateur ou votre adresse e-mail pour continuer",
+              "form": {
+                "usernameOrEmailPlaceholder": "Votre nom d'utilisateur ou adresse e-mail"
+              },
+              "link": {
+                "forgotPassword": "Mot de passe oublié",
+                "notRegistered": "Pas encore inscrit ?",
+                "createAccount": "Créer un compte"
+              },
+              "button": {
+                "oauthLogin": "Connexion OAuth"
+              }
+            },
+            "passkey": {
+              "title": "S'authentifier avec une clé d'accès",
+              "subtitle": "Nous avons trouvé une clé d'accès associée à {username}",
+              "button": {
+                "usePasskey": "Utiliser la clé d'accès",
+                "usePassword": "Utiliser le mot de passe"
+              }
+            },
+            "password": {
+              "title": "Entrez votre mot de passe",
+              "subtitle": "Veuillez entrer votre mot de passe pour {username}",
+              "form": {
+                "passwordPlaceholder": "Entrez votre mot de passe"
+              },
+              "button": {
+                "signIn": "Se connecter",
+                "forgotPassword": "Mot de passe oublié"
+              }
+            },
+            "totp": {
+              "title": "Authentification à deux facteurs",
+              "welcomeBack": "Bon retour {username} !",
+              "enterCode": "Entrez le code à 6 chiffres de votre application d'authentification",
+              "button": {
+                "verify": "Vérifier le code",
+                "useRecoveryCode": "Utiliser un code de récupération",
+                "useTotp": "Utiliser le TOTP"
+              }
+            },
+            "totpRecovery": {
+              "subtitle": "Entrez un code de récupération",
+              "form": {
+                "label": "Code de récupération",
+                "placeholder": "Entrez un code de récupération"
+              }
+            }
+          }
+        },
+        "register": {
+          "title": "Inscription",
+          "subtitle": "Veuillez entrer vos informations pour vous inscrire",
+          "button": {
+            "register": "S'inscrire"
+          }
+        },
+        "forgotPassword": {
+          "title": "Mot de passe oublié",
+          "subtitle": "Entrez votre adresse e-mail pour recevoir les instructions de réinitialisation de votre mot de passe",
+          "button": {
+            "request": "Demander la réinitialisation du mot de passe"
+          },
+          "success": "Un e-mail vous a été envoyé avec les instructions pour réinitialiser votre mot de passe."
+        },
+        "resetPassword": {
+          "title": "Réinitialiser le mot de passe",
+          "subtitle": "Veuillez entrer votre nouveau mot de passe",
+          "button": {
+            "reset": "Réinitialiser le mot de passe"
+          },
+          "toast": {
+            "success": "Le mot de passe a été réinitialisé."
+          }
+        },
+        "oauth": {
+          "title": "S'authentifier avec OAuth",
+          "subtitle": "Choisissez l'un des fournisseurs ci-dessous pour vous connecter"
+        }
+      },
       "oobe": {
         "welcome": {
           "title": "Bienvenue sur Calagopus",
@@ -265,7 +2740,7 @@
         },
         "login": {
           "title": "Se reconnecter",
-          "alert": "Vous vous êtes fait déconnecté durant le processus de configuration. Veuillez vous reconnecter pour continuer de là où vous vous êtes arrêté.",
+          "alert": "Vous vous êtes fait déconnecter durant le processus de configuration. Veuillez vous reconnecter pour continuer de là où vous vous êtes arrêté.",
           "form": {
             "usernamePlaceholder": "admin",
             "passwordPlaceholder": "Entrez un mot de passe fort"
@@ -282,7 +2757,9 @@
             "backupName": "Nom de la configuration de sauvegarde",
             "backupNamePlaceholder": "Baguette Cloud",
             "backupDisk": "Disque de sauvegarde",
-            "backupDiskPlaceholder": "Disque de sauvegarde"
+            "backupDiskPlaceholder": "Disque de sauvegarde",
+            "locationFlag": "Drapeau de l'emplacement",
+            "locationFlagPlaceholder": "Le meilleur pays"
           },
           "button": {
             "create": "Créer & continuer"
@@ -290,7 +2767,9 @@
         },
         "node": {
           "title": "Configuration du nœud",
+          "allocationsTitle": "Configuration des allocations",
           "form": {
+            "ip": "IP",
             "name": "Nom",
             "namePlaceholder": "Mon serveur",
             "urlPlaceholder": "URL",
@@ -302,7 +2781,56 @@
             "sftpPortPlaceholder": "Port SFTP"
           },
           "error": {
-            "noLocations": "Quelque chose s'est mal placé. Pas d'emplacements trouvés."
+            "noLocations": "Quelque chose s'est mal passé. Pas d'emplacements trouvés."
+          },
+          "button": {
+            "create": "Créer & continuer"
+          }
+        },
+        "nodeConfiguration": {
+          "title": "Configuration du nœud",
+          "error": {
+            "noNodes": "Quelque chose s'est mal passé. Aucun nœud trouvé.",
+            "connectionError": "Quelque chose s'est mal passé. Erreur de connexion."
+          },
+          "successMessage": "La connexion à votre nœud a été vérifiée avec succès. Vous pouvez maintenant continuer.",
+          "configurationDescription": "Placez ceci dans le fichier de configuration à `{file}` ou exécutez :",
+          "button": {
+            "verify": "Vérifier la connexion"
+          }
+        },
+        "eggRepositories": {
+          "title": "Dépôts d'Eggs",
+          "description": "Ce sont les dépôts source de vos Eggs. Vous pouvez changer ces dépôts à tout moment.",
+          "repositories": {
+            "pterodactylGame": {
+              "title": "Eggs de jeux Pterodactyl",
+              "description": "Eggs pour des jeux comme Minecraft, Terraria, et bien d'autres."
+            },
+            "pterodactylApplication": {
+              "title": "Eggs d'applications Pterodactyl",
+              "description": "Eggs pour des applications comme Grafana, Meilisearch, et diverses bases de données."
+            },
+            "pterodactylGeneral": {
+              "title": "Eggs génériques Pterodactyl",
+              "description": "Eggs pour des environnements d'exécution génériques comme Node JS, Java, et Rust."
+            }
+          }
+        },
+        "server": {
+          "title": "Serveur",
+          "existingServer": "Un serveur a déjà été créé. Vous pourrez modifier les paramètres plus tard dans le menu d'administration.",
+          "egg": {
+            "title": "Egg",
+            "description": "Mettons en marche votre premier serveur. Quel Egg souhaitez-vous utiliser ?",
+            "nestDescription": "Pour commencer à utiliser cet Egg, vous devrez créer un Nest ; les Nests sont des collections d'Eggs. Donnez-lui un nom :"
+          },
+          "server": {
+            "title": "Serveur",
+            "nestDescription": "Pour commencer à utiliser cet Egg, vous devrez créer un Nest ; les Nests sont des collections d'Eggs. Donnez-lui un nom :"
+          },
+          "error": {
+            "noNodes": "Quelque chose s'est mal passé. Aucun nœud trouvé."
           },
           "button": {
             "create": "Créer & continuer"
@@ -334,7 +2862,12 @@
               "subtitle": "Paramètres et préférences du panel configurés"
             },
             "location": "Emplacement",
-            "node": "Nœud"
+            "node": "Nœud",
+            "eggRepositories": {
+              "title": "Dépôts d'Eggs",
+              "subtitle": "{count} dépôts"
+            },
+            "server": "Serveur"
           },
           "badge": {
             "skipped": "Passé"
@@ -349,7 +2882,12 @@
             "removeFromGroup": "Retirer du groupe",
             "addToGroup": "Ajouter au groupe",
             "noGroups": "Pas de groupes disponibles auxquels ajouter le serveur",
-            "noGroup": "Ce serveur n'est dans aucun groupe"
+            "noGroup": "Ce serveur n'est dans aucun groupe",
+            "addServerToGroup": "Ajouter le serveur au groupe",
+            "groupActions": "Actions de groupe"
+          },
+          "badge": {
+            "foreign": "Externe"
           },
           "tabs": {
             "groupedServers": {
@@ -383,6 +2921,13 @@
                     "noServers": "Tous les serveurs sont déjà dans ce groupe.",
                     "toast": {
                       "added": "Serveur ajouté au groupe."
+                    }
+                  },
+                  "removeServerFromGroup": {
+                    "title": "Confirmer le retrait du serveur",
+                    "content": "Êtes-vous sûr de vouloir retirer **{server}** de **{group}** ?",
+                    "toast": {
+                      "removed": "Serveur retiré du groupe."
                     }
                   }
                 },
@@ -425,6 +2970,10 @@
             "requireTwoFactor": {
               "title": "Authentification à deux facteurs requise",
               "description": "L'authentification à deux facteurs est requise pour votre compte. Veuillez la mettre en place ci-dessus pour continuer à utiliser le panel."
+            },
+            "frozen": {
+              "title": "Compte gelé",
+              "description": "Votre compte a été gelé. Vous ne pouvez pas apporter de modifications à votre compte tant qu'il n'est pas dégelé. Veuillez contacter un administrateur pour plus d'informations."
             }
           },
           "containers": {
@@ -439,29 +2988,29 @@
               }
             },
             "email": {
-              "title": "E-mail",
+              "title": "Adresse e-mail",
               "toast": {
-                "updated": "E-mail mise à jour avec succès."
+                "updated": "Adresse e-mail mise à jour avec succès."
               },
               "form": {
-                "newEmail": "Nouvelle e-mail"
+                "newEmail": "Nouvelle adresse e-mail"
               }
             },
             "twoFactor": {
-              "title": "Authentification à double facteurs",
+              "title": "Authentification à deux facteurs",
               "toast": {
-                "disabled": "Authentification à double facteurs désactivée avec succès.",
-                "enabled": "Authentification à double facteurs activée avec succès. Veuillez copier vos codes de récupération."
+                "disabled": "Authentification à deux facteurs désactivée avec succès.",
+                "enabled": "Authentification à deux facteurs activée avec succès. Veuillez copier vos codes de récupération."
               },
               "modal": {
                 "disableTwoFactor": {
-                  "title": "Désactiver l'authentification à double facteurs",
-                  "description": "Désactiver l'authentification à double facteurs rendra votre compte moins sécurisé."
+                  "title": "Désactiver l'authentification à deux facteurs",
+                  "description": "Désactiver l'authentification à deux facteurs rendra votre compte moins sécurisé."
                 },
                 "setupTwoFactor": {
-                  "title": "Configurer l'authentification à double facteurs",
+                  "title": "Configurer l'authentification à deux facteurs",
                   "description": "Protégez votre compte des accès non-autorisés. Un code de vérification vous sera demandé à chaque connexion.",
-                  "descriptionQR": "Scannez le QR code ci-dessus en utilisant l'application à double facteurs de votre choix. Ensuite, entrez le code à 6 chiffres généré dans le champ ci-dessous."
+                  "descriptionQR": "Scannez le QR code ci-dessus en utilisant l'application d'authentification à deux facteurs de votre choix. Ensuite, entrez le code à 6 chiffres généré dans le champ ci-dessous."
                 },
                 "recoveryCodes": {
                   "title": "Codes de récupération",
@@ -469,11 +3018,11 @@
                 }
               },
               "button": {
-                "disableTwoFactor": "Désactiver le deuxième facteur",
-                "setupTwoFactor": "Configurer le deuxième facteur"
+                "disableTwoFactor": "Désactiver l'authentification à deux facteurs",
+                "setupTwoFactor": "Configurer l'authentification à deux facteurs"
               },
-              "twoFactorEnabled": "La vérification du double facteur est actuellement activée.",
-              "twoFactorDisabled": "La vérification double facteur n'est pas activée pour votre compte. Cliquez le bouton ci-dessous pour commencer à la configurer.",
+              "twoFactorEnabled": "La vérification à deux facteurs est actuellement activée.",
+              "twoFactorDisabled": "La vérification à deux facteurs n'est pas activée pour votre compte. Cliquez sur le bouton ci-dessous pour commencer à la configurer.",
               "twoFactorLastUsed": "Dernière utilisation : {timestamp}"
             },
             "account": {
@@ -500,6 +3049,16 @@
         },
         "securityKeys": {
           "title": "Clés de sécurité",
+          "subtitle": "{current} sur {max} clés de sécurité maximum créées.",
+          "table": {
+            "columns": {
+              "credentialId": "ID d'identifiant"
+            }
+          },
+          "tooltip": {
+            "secureContextRequired": "Un contexte sécurisé (HTTPS) est requis pour utiliser les clés de sécurité.",
+            "limitReached": "Vous êtes limité à {max} clés de sécurité."
+          },
           "modal": {
             "createSecurityKey": {
               "title": "Créer une clé de sécurité",
@@ -516,7 +3075,7 @@
             },
             "deleteSecurityKey": {
               "title": "Confirmer la suppression de la clé de sécurité",
-              "content": "Êtes-vous sur de vouloir supprimer **{key}** de votre compte ?",
+              "content": "Êtes-vous sûr de vouloir supprimer **{key}** de votre compte ?",
               "toast": {
                 "deleted": "Clé de sécurité supprimée avec succès."
               }
@@ -545,12 +3104,29 @@
         "shortcuts": {
           "title": "Raccourcis clavier",
           "subtitle": "Utilisez ces raccourcis clavier pour naviguer et interagir avec le panel plus efficacement.",
+          "label": {
+            "disabled": "Désactivé",
+            "modified": "Modifié",
+            "recording": "Appuyez sur des touches..."
+          },
+          "button": {
+            "rebind": "Réassigner",
+            "resetAll": "Tout réinitialiser",
+            "copy": "Tout copier",
+            "paste": "Coller"
+          },
+          "toast": {
+            "imported": "{shortcuts} mis à jour.",
+            "importedNone": "Aucun raccourci n'a été modifié.",
+            "importErrors": "{unknown} et {invalid} ignorés.",
+            "resetAll": "Tous les raccourcis réinitialisés par défaut."
+          },
           "detectedMac": "macOS détecté",
           "detectedWindows": "Windows/Linux détecté",
           "fileManager": {
             "title": "Gestionnaire de fichiers",
             "selectAll": "Sélectionner tous les fichiers",
-            "cutFiles": "Couper les fichiers sélectionnées",
+            "cutFiles": "Couper les fichiers sélectionnés",
             "copyFiles": "Copier les fichiers sélectionnés",
             "duplicateFile": "Dupliquer le fichier sélectionné",
             "pasteFiles": "Coller fichiers",
@@ -560,7 +3136,7 @@
             "moveDownSelection": "Déplacer la sélection vers le bas",
             "renameFile": "Renommer le fichier",
             "deselectAll": "Désélectionner tous les fichiers",
-            "deleteFiles": "Supprimer les fichiers sélectionner"
+            "deleteFiles": "Supprimer les fichiers sélectionnés"
           },
           "table": {
             "title": "Navigation des tables",
@@ -582,6 +3158,10 @@
         },
         "sshKeys": {
           "title": "Clés SSH",
+          "subtitle": "{current} sur {max} clés SSH maximum créées.",
+          "tooltip": {
+            "limitReached": "Vous êtes limité à {max} clés SSH."
+          },
           "table": {
             "columns": {
               "fingerprint": "Empreinte"
@@ -624,6 +3204,34 @@
             }
           }
         },
+        "commandSnippets": {
+          "title": "Extraits de commande",
+          "subtitle": "{current} sur {max} extraits de commande maximum créés.",
+          "tooltip": {
+            "limitReached": "Vous êtes limité à {max} extraits de commande."
+          },
+          "modal": {
+            "createCommandSnippet": {
+              "title": "Créer un extrait de commande",
+              "toast": {
+                "created": "Extrait de commande créé."
+              }
+            },
+            "editCommandSnippet": {
+              "title": "Modifier l'extrait de commande",
+              "toast": {
+                "updated": "Extrait de commande mis à jour."
+              }
+            },
+            "deleteCommandSnippet": {
+              "title": "Confirmer la suppression de l'extrait de commande",
+              "content": "Êtes-vous sûr de vouloir supprimer **{name}** de votre compte ?",
+              "toast": {
+                "removed": "Extrait de commande supprimé."
+              }
+            }
+          }
+        },
         "oauthLinks": {
           "title": "Liens OAuth",
           "button": {
@@ -647,6 +3255,10 @@
         },
         "apiKeys": {
           "title": "Clés API",
+          "subtitle": "{current} sur {max} clés API maximum créées.",
+          "tooltip": {
+            "limitReached": "Vous êtes limité à {max} clés API."
+          },
           "button": {
             "apiDocumentation": "Documentation API"
           },
@@ -676,6 +3288,13 @@
               "toast": {
                 "removed": "Clé API supprimée."
               }
+            },
+            "recreateApiKey": {
+              "title": "Recréer la clé API",
+              "content": "Recréer une clé API générera une nouvelle clé et invalidera l'ancienne. Êtes-vous sûr de vouloir recréer la clé API **{name}** ?",
+              "toast": {
+                "recreated": "Clé API recréée."
+              }
             }
           },
           "form": {
@@ -684,6 +3303,19 @@
             "userPermissions": "Permissions utilisateur",
             "serverPermissions": "Permissions serveur",
             "adminPermissions": "Permissions admin"
+          },
+          "create": {
+            "title": "Créer une clé API",
+            "subtitle": "Une application demande la création d'une clé API pour votre compte.",
+            "alert": {
+              "adminPermissions": "Cette clé API demande des **permissions admin**. Toute personne en possession de cette clé pourra effectuer des actions administratives sur ce panel en votre nom. Ne continuez que si vous faites entièrement confiance à l'application demandeuse.",
+              "callbackUrl": "Après la création, la nouvelle clé API sera envoyée à **{url}**."
+            },
+            "noPermissions": "Cette clé API n'aura aucune permission.",
+            "keyCreated": "Votre nouvelle clé API a été créée. Veillez à la copier maintenant, car elle ne sera plus affichée.",
+            "button": {
+              "goToApiKeys": "Aller aux clés API"
+            }
           }
         },
         "activity": {
@@ -692,7 +3324,7 @@
       },
       "server": {
         "viewAdmin": {
-          "title": "Voir admin"
+          "title": "Voir dans l'espace admin"
         },
         "console": {
           "title": "Console",
@@ -700,25 +3332,44 @@
             "placeholder": "Entrez une commande...",
             "ariaLabel": "Entrée commande console."
           },
+          "modal": {
+            "sshDetails": {
+              "title": "Détails SSH",
+              "form": {
+                "command": "Commande SSH"
+              },
+              "launch": "Lancer"
+            }
+          },
           "toast": {
-            "installCancelled": "Installation du serveur annulée."
+            "installCancelled": "Installation du serveur annulée.",
+            "transferCancelled": "Transfert du serveur annulé."
           },
           "notification": {
             "restoringBackup": "Votre serveur est actuellement en train d'être restauré depuis une sauvegarde. Veuillez patienter...",
-            "installing": "Votre serveur est en train d'être installé. Veuillez patienter..."
+            "installing": "Votre serveur est en train d'être installé. Veuillez patienter...",
+            "suspended": "Votre serveur est actuellement suspendu. Aucune action ne peut être effectuée tant que la suspension n'est pas levée.",
+            "suspendedAdmin": "Ce serveur est actuellement suspendu. Étant administrateur, vous pouvez toujours y accéder, mais les actions sont limitées.",
+            "nodeMaintenance": "Votre serveur est sur un nœud actuellement en maintenance.",
+            "transferring": "Votre serveur est en cours de transfert vers un autre nœud.",
+            "pendingRestart": "Votre serveur a des changements en attente nécessitant un redémarrage. Veuillez redémarrer votre serveur pour appliquer ces changements."
           },
           "message": {
             "serverMarkedAs": "Serveur marqué comme {state}...",
             "transferFailed": "Le transfert a échoué.",
-            "pullingImage": "Votre serveur est entrain de récupérer son image Docker. Veuillez patienter...",
+            "pullingImage": "Votre serveur est en train de récupérer son image Docker. Veuillez patienter...",
             "pulling": "Récupération",
-            "extracting": "Extraction"
+            "extracting": "Extraction",
+            "installFailed": "L'installation a échoué.",
+            "installCompleted": "L'installation s'est terminée avec succès.",
+            "transferCompleted": "Le transfert s'est terminé avec succès. Reconnexion au serveur..."
           },
           "tooltip": {
             "search": "Rechercher",
             "commandHistory": "Historique de commande",
             "decreaseFontSize": "Réduire taille de texte",
-            "increaseFontSize": "Augmenter taille de texte"
+            "increaseFontSize": "Augmenter taille de texte",
+            "sshDetails": "Détails SSH"
           },
           "drawer": {
             "commandHistory": {
@@ -740,6 +3391,17 @@
               },
               "button": {
                 "accept": "Accepter EULA"
+              }
+            },
+            "javaVersion": {
+              "title": "Version de Java non prise en charge",
+              "content": "Ce serveur utilise actuellement une version de Java non prise en charge et ne peut pas être démarré.",
+              "contentDetails": "Veuillez sélectionner une image Docker prise en charge dans la liste ci-dessous pour continuer à démarrer le serveur.",
+              "toast": {
+                "updated": "Image Docker mise à jour avec succès."
+              },
+              "button": {
+                "update": "Mettre à jour l'image Docker"
               }
             }
           },
@@ -777,6 +3439,9 @@
           "titleEditorViewing": "Affichage de {file}",
           "titleEditorEditing": "Modification de {file}",
           "titleEditorNew": "Nouveau fichier",
+          "titleEditorPlaying": "Lecture de {file}",
+          "titleDiffRevisionVsCurrent": "{file} - Révision n°{revision} vs actuel",
+          "titleDiffRevisionVsRevision": "{file} - Révision n°{previousRevision} vs n°{revision}",
           "table": {
             "columns": {
               "modified": "Modifié"
@@ -797,11 +3462,27 @@
             "directory": "Répertoire",
             "fileFromPull": "Fichier depuis récupération",
             "fileFromUpload": "Fichier depuis téléversement",
-            "directoryFromUpload": "Répertoire depuis téléversement"
+            "directoryFromUpload": "Répertoire depuis téléversement",
+            "connect": "Connecter",
+            "connectSftp": "via SFTP",
+            "connectVscode": "via VS Code",
+            "fingerprint": "Empreinte",
+            "more": "Plus"
           },
           "actionBar": {
             "copyHere": "Copier {files} ici",
             "moveHere": "Déplacer {files} ici"
+          },
+          "tooltip": {
+            "fileHistory": "Historique du fichier",
+            "largestDirectories": "Analyser la taille des répertoires",
+            "dragToMove": "Glisser pour déplacer",
+            "back": "Reculer de {seconds} secondes",
+            "forward": "Avancer de {seconds} secondes",
+            "play": "Lecture",
+            "pause": "Pause",
+            "mute": "Couper le son",
+            "unmute": "Activer le son"
           },
           "searchBanner": {
             "resultsTitle": "Résultats de recherche ({files} trouvés)",
@@ -822,29 +3503,61 @@
             "copying": "Copie de {path} vers {destination}",
             "copyingMany": "Copie de {files}",
             "receivingRemote": "Réception de {files} depuis serveur distant",
-            "sendingRemote": "Envoi de {files} vers serveur distant"
+            "sendingRemote": "Envoi de {files} vers serveur distant",
+            "rateLimited": "Votre téléversement a été limité en débit. En attente...",
+            "cancelAllUploads": "Annuler tous les téléversements",
+            "cancelAllOperations": "Annuler toutes les opérations"
+          },
+          "dropzone": {
+            "title": "Déposez les fichiers ici pour les téléverser",
+            "subtitle": "Relâchez pour démarrer le téléversement"
           },
           "settings": {
             "clickOnce": "Cliquez une fois pour ouvrir fichier ou dossier",
             "editorMinimap": "Afficher la minicarte de fichier",
             "editorLineOverflow": "Saut de ligne en débordement",
-            "imageViewerSmoothing": "Adoucir l'image (anti-aliasing)"
+            "imageViewerSmoothing": "Adoucir l'image (anti-aliasing)",
+            "preferPhysicalSize": "Afficher la taille physique au lieu de la taille logique",
+            "vscodeUriScheme": "Schéma d'URI VS Code"
           },
           "toast": {
             "operationCancelled": "Opération annulée",
             "copyingStarted": "Copie de {files} commencée.",
-            "filesCouldNotBeMoved": "Les fichiers n'ont pas pu être déplacées.",
+            "filesCouldNotBeMoved": "Les fichiers n'ont pas pu être déplacés.",
             "filesMoved": "{files} déplacés.",
             "downloadStarted": "Téléchargement démarré.",
             "filesDeleted": "Les fichiers ont été supprimés.",
             "archiveCreationStarted": "La création de l'archive a commencé.",
-            "fileCopyingStarted": "La copie de fichier a commencée.",
+            "fileCopyingStarted": "La copie de fichier a commencé.",
             "fileInfoRetrieved": "Informations du fichier récupérées avec succès.",
-            "filePullingStarted": "La récupération du fichier a commencée.",
+            "filePullingStarted": "La récupération du fichier a commencé.",
             "fileRenamed": "Le fichier a été renommé.",
             "fileCouldNotBeRenamed": "Le fichier n'a pas pu être renommé.",
             "permissionsUpdated": "Les permissions ont été mises à jour.",
-            "fileSaved": "Le fichier a été sauvegardé."
+            "fileSaved": "Le fichier a été sauvegardé.",
+            "allOperationsCancelled": "Toutes les opérations ont été annulées.",
+            "filesRenamed": "{files} renommés.",
+            "permissionsUpdatedMany": "Les permissions ont été mises à jour pour {files}.",
+            "permissionsCouldNotBeUpdated": "Les permissions n'ont pas pu être mises à jour."
+          },
+          "drawer": {
+            "revisions": {
+              "title": "Historique du fichier",
+              "noRevisions": "Aucune révision trouvée pour ce fichier.",
+              "restored": "Révision restaurée dans l'éditeur.",
+              "badge": {
+                "fullSnapshot": "Instantané complet"
+              },
+              "tooltip": {
+                "restore": "Restaurer cette révision dans l'éditeur",
+                "viewDiff": "Voir les différences avec le fichier actuel",
+                "compareToPrevious": "Comparer à la révision précédente"
+              },
+              "diff": {
+                "original": "Révision",
+                "current": "Actuel"
+              }
+            }
           },
           "modal": {
             "activeUploads": {
@@ -852,7 +3565,7 @@
               "content": "Êtes-vous sûr de vouloir quitter la page ? Vous avez {files} téléversements de fichier actifs. Si vous quittez la page, les téléversements seront annulés."
             },
             "unsavedChanges": {
-              "title": "Changements non sauvegardées",
+              "title": "Changements non sauvegardés",
               "content": "Vous avez des changements non sauvegardés dans l'éditeur de fichiers. Êtes-vous sûr de vouloir quitter cette page ? Si vous quittez, vos changements seront perdus."
             },
             "createArchive": {
@@ -895,7 +3608,10 @@
               "breakdown": "Résumé de permission",
               "readPermission": "Permission lecture (4)",
               "writePermission": "Permission écriture (2)",
-              "executePermission": "Permission exécution (1)"
+              "executePermission": "Permission exécution (1)",
+              "form": {
+                "recursive": "Appliquer les changements de manière récursive à tous les fichiers et sous-répertoires de ce répertoire"
+              }
             },
             "renameFile": {
               "title": "Renommer fichier"
@@ -904,7 +3620,7 @@
               "title": "Rechercher fichiers",
               "placeholder": "Chercher des fichiers...",
               "advancedFilters": "Filtres avancés",
-              "pathPatterns": "Patternes de chemins",
+              "pathPatterns": "Motifs de chemins",
               "include": "Inclure",
               "exclude": "Exclure",
               "caseInsensitive": "Insensible à la casse",
@@ -921,7 +3637,7 @@
               "title": "Récupérer fichier",
               "form": {
                 "fileUrl": "URL du fichier",
-                "query": "Tester"
+                "query": "Requête"
               },
               "createdAs": "Ce fichier sera créé en tant que ",
               "pull": "Récupérer"
@@ -929,6 +3645,121 @@
             "sftpDetails": {
               "title": "Détails SFTP",
               "launch": "Lancer"
+            },
+            "draftRestore": {
+              "title": "Restaurer le brouillon",
+              "content": "Un brouillon de ce fichier a été trouvé dans votre navigateur. Souhaitez-vous le restaurer ?",
+              "contentHashMismatch": "Le fichier a été modifié sur le serveur depuis l'enregistrement de ce brouillon. Restaurer le brouillon pourrait écraser ces changements."
+            },
+            "fileFingerprints": {
+              "title": "Empreinte du fichier",
+              "form": {
+                "algorithm": "Algorithme",
+                "fingerprint": "Empreinte"
+              },
+              "button": {
+                "calculate": "Calculer l'empreinte"
+              }
+            },
+            "details": {
+              "title": "Détails du fichier",
+              "path": "Chemin",
+              "mode": "Mode",
+              "logicalSize": "Taille logique",
+              "physicalSize": "Taille physique",
+              "mimeType": "Type MIME",
+              "lastModifiedAt": "Dernière modification le",
+              "createdAt": "Créé le"
+            },
+            "massRename": {
+              "title": "Renommer les fichiers",
+              "find": "Rechercher",
+              "findPlaceholder": "Texte à rechercher",
+              "replace": "Remplacer par",
+              "replacePlaceholder": "Texte de remplacement",
+              "scope": "Appliquer à",
+              "scopeName": "Nom",
+              "scopeExtension": "Extension",
+              "scopeFull": "Nom complet",
+              "section": {
+                "matchOptions": "Options de correspondance",
+                "affixes": "Préfixe et suffixe",
+                "caseConversion": "Conversion de casse",
+                "numbering": "Numérotation"
+              },
+              "affix": {
+                "prefix": "Préfixe",
+                "suffix": "Suffixe",
+                "help": "Les deux peuvent inclure {token} pour le numéro ; un suffixe ajoute un compteur à chaque nom."
+              },
+              "option": {
+                "regex": "Utiliser une expression régulière",
+                "regexDescription": "Traite le texte recherché comme une regex ; référencez les groupes avec $1, $2 dans le remplacement.",
+                "caseSensitive": "Sensible à la casse",
+                "allOccurrences": "Remplacer toutes les occurrences"
+              },
+              "case": {
+                "label": "Convertir la casse",
+                "none": "Aucun changement",
+                "lower": "minuscules",
+                "upper": "MAJUSCULES",
+                "title": "Casse de Titre",
+                "capitalize": "Première lettre en majuscule"
+              },
+              "numbering": {
+                "enable": "Activer la numérotation",
+                "help": "Insérez {token} dans le texte recherché, remplacé, préfixe ou suffixe où le numéro doit apparaître.",
+                "start": "Commencer à",
+                "step": "Pas",
+                "padding": "Chiffres minimum"
+              },
+              "preview": {
+                "title": "Aperçu",
+                "original": "Original",
+                "newName": "Nouveau nom",
+                "unchanged": "Inchangé",
+                "conflict": "Nom déjà utilisé",
+                "duplicate": "Cible en double",
+                "invalid": "Nom invalide",
+                "invalidRegex": "Expression régulière invalide",
+                "empty": "Aucun fichier sélectionné."
+              },
+              "summary": "{changed} sur {total} seront renommés",
+              "conflictWarning": "Résolvez les conflits de noms en surbrillance avant de renommer."
+            },
+            "largestDirectories": {
+              "title": "Plus grands répertoires",
+              "empty": "Aucun répertoire trouvé."
+            }
+          }
+        },
+        "mounts": {
+          "title": "Montages",
+          "table": {
+            "columns": {
+              "target": "Cible",
+              "mounted": "Monté",
+              "readOnly": "Lecture seule"
+            }
+          },
+          "button": {
+            "attach": "Attacher",
+            "detach": "Détacher"
+          },
+          "modal": {
+            "attachMount": {
+              "title": "Attacher le montage",
+              "content": "Voulez-vous attacher **{name}** à `{target}` ?",
+              "toast": {
+                "attached": "{name} a été monté sur votre serveur."
+              }
+            },
+            "detachMount": {
+              "title": "Détacher le montage",
+              "content": "Voulez-vous détacher **{name}** de `{target}` ?",
+              "toast": {
+                "detached": "{name} a été retiré de votre serveur."
+              }
             }
           }
         },
@@ -980,14 +3811,431 @@
               "toast": {
                 "deleted": "Base de données supprimée."
               }
+            },
+            "recreateDatabase": {
+              "title": "Confirmer la recréation de la base de données",
+              "content": "Recréer une base de données supprimera définitivement toutes les données de la base **{name}** et en créera une nouvelle avec les mêmes détails de connexion.",
+              "toast": {
+                "recreated": "Base de données recréée."
+              }
             }
           }
         },
         "schedules": {
-          "title": "Planifications"
+          "title": "Planifications",
+          "subtitle": "{current} sur {max} planifications maximum créées.",
+          "dropzone": {
+            "title": "Déposez des fichiers ici pour les importer en tant que planifications",
+            "subtitle": "Relâchez pour démarrer l'importation"
+          },
+          "tooltip": {
+            "limitReached": "Ce serveur est limité à {max} planifications."
+          },
+          "table": {
+            "columns": {
+              "lastRun": "Dernière exécution",
+              "lastFailure": "Dernier échec",
+              "status": "Statut"
+            }
+          },
+          "button": {
+            "trigger": "Déclencher",
+            "triggerWithCondition": "Déclencher (ne pas ignorer la condition)",
+            "triggerSkipCondition": "Déclencher (ignorer la condition)",
+            "addTrigger": "Ajouter un déclencheur",
+            "addCondition": "Ajouter une condition",
+            "addStep": "Ajouter une étape",
+            "createFirstStep": "Créer la première étape",
+            "addOutput": "Ajouter une sortie",
+            "addFile": "Ajouter un fichier",
+            "exitEditor": "Quitter l'éditeur"
+          },
+          "toast": {
+            "imported": "Planification importée.",
+            "created": "Planification créée.",
+            "updated": "Planification mise à jour.",
+            "deleted": "Planification supprimée.",
+            "triggered": "Planification déclenchée.",
+            "exported": "Planification exportée.",
+            "parseError": "Échec de l'analyse de la planification : {error}",
+            "step": {
+              "created": "Étape de planification créée.",
+              "updated": "Étape de planification mise à jour.",
+              "deleted": "Étape de planification supprimée."
+            }
+          },
+          "enum": {
+            "schedulePreConditionType": {
+              "none": "Aucune",
+              "and": "ET (toutes doivent être vraies)",
+              "or": "OU (au moins une doit être vraie)",
+              "not": "NON (ne doit pas être vraie)",
+              "serverState": "État du serveur",
+              "uptime": "Temps de fonctionnement",
+              "cpuUsage": "Utilisation CPU",
+              "memoryUsage": "Utilisation mémoire",
+              "diskUsage": "Utilisation disque",
+              "fileExists": "Le fichier existe"
+            },
+            "scheduleConditionType": {
+              "none": "Aucune",
+              "and": "ET (toutes doivent être vraies)",
+              "or": "OU (au moins une doit être vraie)",
+              "not": "NON (ne doit pas être vraie)",
+              "variableExists": "La variable existe",
+              "variableContains": "La variable contient",
+              "variableEquals": "La variable est égale à",
+              "variableStartsWith": "La variable commence par",
+              "variableEndsWith": "La variable se termine par"
+            },
+            "scheduleComparator": {
+              "smallerThan": "Inférieur à",
+              "smallerThanOrEqual": "Inférieur ou égal à",
+              "equal": "Égal à",
+              "greaterThanOrEqual": "Supérieur ou égal à",
+              "greaterThan": "Supérieur à"
+            }
+          },
+          "modal": {
+            "createSchedule": {
+              "title": "Créer une planification"
+            },
+            "updateSchedule": {
+              "title": "Modifier la planification"
+            },
+            "deleteSchedule": {
+              "title": "Confirmer la suppression de la planification",
+              "content": "Êtes-vous sûr de vouloir supprimer {name} de ce serveur ?"
+            },
+            "createStep": {
+              "title": "Créer une étape de planification"
+            },
+            "editStep": {
+              "title": "Modifier l'étape de planification"
+            },
+            "deleteStep": {
+              "title": "Confirmer la suppression de l'étape de planification",
+              "content": "Êtes-vous sûr de vouloir supprimer cette étape de planification ?"
+            }
+          },
+          "view": {
+            "badge": {
+              "running": "En cours"
+            },
+            "tooltip": {
+              "cannotTrigger": "Impossible de déclencher une planification désactivée"
+            },
+            "tabs": {
+              "actions": "Actions",
+              "conditions": "Conditions",
+              "triggers": "Déclencheurs"
+            },
+            "sections": {
+              "actions": "Actions de la planification",
+              "preConditions": "Pré-conditions de la planification",
+              "triggers": "Déclencheurs de la planification"
+            },
+            "alert": {
+              "noActions": "Aucune action configurée pour cette planification",
+              "noTriggers": "Aucun déclencheur configuré pour cette planification"
+            }
+          },
+          "form": {
+            "scheduleName": "Nom de la planification",
+            "triggersList": "Déclencheurs",
+            "triggerNumber": "Déclencheur {number}",
+            "actionType": "Type d'action",
+            "conditionType": "Type de condition",
+            "serverState": "État du serveur",
+            "comparator": "Comparateur",
+            "rootPath": "Chemin racine",
+            "outputInto": "Sortir dans",
+            "caseInsensitive": "Insensible à la casse",
+            "ignoreFailure": "Ignorer l'échec",
+            "runInForeground": "Exécuter au premier plan"
+          },
+          "condition": {
+            "variable": "Variable",
+            "equals": "Égale à",
+            "contains": "Contient",
+            "startsWith": "Commence par",
+            "endsWith": "Se termine par",
+            "allMustBeTrue": "Toutes les conditions doivent être vraies :",
+            "anyMustBeTrue": "Au moins une condition doit être vraie :",
+            "mustNotBeTrue": "La condition ne doit pas être vraie :"
+          },
+          "preCondition": {
+            "valueSeconds": "Valeur (secondes)",
+            "valuePercent": "Valeur (%)",
+            "value": "Valeur"
+          },
+          "triggers": {
+            "cron": {
+              "title": "Cron",
+              "form": {
+                "cronSchedule": "Planification Cron"
+              },
+              "card": {
+                "content": "À l'intervalle Cron {schedule}, la prochaine exécution est {timestamp} - la dernière était {lastTimestamp}."
+              },
+              "invalidCron": "Expression cron invalide"
+            },
+            "powerAction": {
+              "title": "Action d'alimentation",
+              "card": {
+                "content": "Lorsque l'action d'alimentation `{action}` est demandée."
+              }
+            },
+            "serverState": {
+              "title": "État du serveur",
+              "card": {
+                "content": "Lorsque l'état du serveur `{state}` est atteint."
+              }
+            },
+            "backupStatus": {
+              "title": "Statut de la sauvegarde",
+              "form": {
+                "backupStatus": "Statut de la sauvegarde"
+              },
+              "card": {
+                "content": "Lorsque la sauvegarde atteint le statut `{status}`."
+              }
+            },
+            "consoleLine": {
+              "title": "Ligne de console",
+              "card": {
+                "content": "Lorsque la sortie console atteint une ligne contenant `{contains}`"
+              }
+            },
+            "crash": {
+              "title": "Plantage",
+              "card": {
+                "content": "Lorsque le serveur plante."
+              }
+            }
+          },
+          "renderer": {
+            "noActionSelected": "Sélectionnez un type d'action à configurer",
+            "noActionDetails": "Détails de l'action non disponibles",
+            "ignoreFailure": "Ignorer l'échec : {value}",
+            "foreground": "Premier plan : {value}"
+          },
+          "steps": {
+            "empty": {
+              "title": "Aucune étape configurée",
+              "description": "Cette planification n'a pas encore d'étapes. Ajoutez des actions pour commencer."
+            },
+            "sleep": {
+              "title": "Attendre",
+              "form": {
+                "duration": "Durée (millisecondes)"
+              },
+              "renderer": {
+                "compact": "Attendre {duration} ms"
+              }
+            },
+            "ensure": {
+              "title": "Garantir",
+              "renderer": {
+                "compact": "Garantir qu'une condition correspond"
+              }
+            },
+            "format": {
+              "title": "Formater",
+              "form": {
+                "formatString": "Chaîne de format",
+                "formatStringDescription": "La chaîne de format. Les variables peuvent être incluses en les entourant de {wrapper}."
+              },
+              "renderer": {
+                "compact": "Formater une chaîne dans {outputInto}"
+              }
+            },
+            "matchRegex": {
+              "title": "Correspondance regex",
+              "form": {
+                "input": "Entrée",
+                "regex": "Regex",
+                "outputs": "Sorties",
+                "outputNumber": "Sortie {number}"
+              },
+              "renderer": {
+                "compact": "Faire correspondre {input} avec la regex {regex}"
+              }
+            },
+            "waitForConsoleLine": {
+              "title": "Attendre une ligne de console",
+              "form": {
+                "timeout": "Délai (millisecondes)"
+              },
+              "renderer": {
+                "compact": "Attendre {timeout} une ligne de console contenant {contains}",
+                "detail": {
+                  "lineContains": "La ligne doit contenir : {contains}",
+                  "caseInsensitive": "Insensible à la casse : {value}",
+                  "timeout": "Délai : {timeout}"
+                }
+              }
+            },
+            "sendCommand": {
+              "title": "Envoyer une commande",
+              "renderer": {
+                "compact": "Exécuter {command}",
+                "detail": {
+                  "command": "Commande : {command}"
+                }
+              }
+            },
+            "sendPower": {
+              "title": "Envoyer un signal d'alimentation",
+              "renderer": {
+                "compact": "Faire {action}",
+                "detail": {
+                  "powerAction": "Action d'alimentation : {action}"
+                }
+              }
+            },
+            "createBackup": {
+              "title": "Créer une sauvegarde",
+              "form": {
+                "backupName": "Nom de la sauvegarde"
+              },
+              "renderer": {
+                "compact": "Créer {name}",
+                "detail": {
+                  "backupName": "Nom de la sauvegarde : {name}",
+                  "ignoredFiles": "Fichiers ignorés : {files}"
+                }
+              }
+            },
+            "createDirectory": {
+              "title": "Créer un répertoire",
+              "renderer": {
+                "compact": "Créer {name} dans {root}",
+                "detail": {
+                  "directory": "Répertoire : {name}",
+                  "root": "Racine : {root}"
+                }
+              }
+            },
+            "writeFile": {
+              "title": "Écrire un fichier",
+              "form": {
+                "content": "Contenu",
+                "appendToFile": "Ajouter au fichier"
+              },
+              "renderer": {
+                "compact": "Écrire dans {file}",
+                "detail": {
+                  "file": "Fichier : {file}",
+                  "append": "Ajout : {value}"
+                }
+              }
+            },
+            "copyFile": {
+              "title": "Copier un fichier",
+              "form": {
+                "sourceFile": "Fichier source"
+              },
+              "renderer": {
+                "compact": "Copier {file} vers {destination}",
+                "detail": {
+                  "from": "De : {file}",
+                  "to": "Vers : {destination}"
+                }
+              }
+            },
+            "deleteFiles": {
+              "title": "Supprimer des fichiers",
+              "form": {
+                "filesToDelete": "Fichiers à supprimer"
+              },
+              "renderer": {
+                "compact": "Supprimer {files}",
+                "detail": {
+                  "root": "Racine : {root}",
+                  "files": "Fichiers : {files}"
+                }
+              }
+            },
+            "renameFiles": {
+              "title": "Renommer des fichiers",
+              "form": {
+                "files": "Fichiers",
+                "from": "de",
+                "to": "vers"
+              },
+              "renderer": {
+                "compact": "Renommer {files}",
+                "detail": {
+                  "root": "Racine : {root}",
+                  "files": "Fichiers : {files}"
+                }
+              }
+            },
+            "compressFiles": {
+              "title": "Compresser des fichiers",
+              "form": {
+                "filesToCompress": "Fichiers à compresser"
+              },
+              "renderer": {
+                "compact": "Compresser {files} dans {root} vers {name}",
+                "detail": {
+                  "output": "Sortie : {name}",
+                  "root": "Racine : {root}",
+                  "format": "Format : {format}",
+                  "files": "Fichiers : {files}"
+                }
+              }
+            },
+            "decompressFile": {
+              "title": "Décompresser un fichier",
+              "form": {
+                "file": "Fichier"
+              },
+              "renderer": {
+                "compact": "Décompresser {file} vers {root}",
+                "detail": {
+                  "file": "Fichier : {file}",
+                  "root": "Racine : {root}"
+                }
+              }
+            },
+            "updateStartupVariable": {
+              "title": "Mettre à jour une variable de démarrage",
+              "renderer": {
+                "compact": "Définir {variable} sur {value}",
+                "detail": {
+                  "variable": "Variable : {variable}",
+                  "value": "Valeur : {value}"
+                }
+              }
+            },
+            "updateStartupCommand": {
+              "title": "Mettre à jour la commande de démarrage",
+              "renderer": {
+                "compact": "Définir sur {command}",
+                "detail": {
+                  "command": "Commande : {command}"
+                }
+              }
+            },
+            "updateStartupDockerImage": {
+              "title": "Mettre à jour l'image Docker",
+              "renderer": {
+                "compact": "Définir sur {image}",
+                "detail": {
+                  "image": "Image : {image}"
+                }
+              }
+            }
+          }
         },
         "subusers": {
           "title": "Sous-utilisateurs",
+          "subtitle": "{current} sur {max} sous-utilisateurs maximum créés.",
+          "tooltip": {
+            "limitReached": "Ce serveur est limité à {max} sous-utilisateurs."
+          },
           "table": {
             "columns": {
               "twoFactorEnabled": "2FA activé",
@@ -1003,7 +4251,8 @@
               },
               "form": {
                 "emailPlaceholder": "Entrez l'adresse e-mail du sous-utilisateur.",
-                "permissions": "Permissions"
+                "permissions": "Permissions",
+                "ignoredFilesDescription": "Les fichiers et répertoires correspondant à ces motifs seront masqués pour ce sous-utilisateur. Utilise des motifs glob de style gitignore (ex. `*.env`, `secrets/`). Préfixez un motif avec `!` pour démasquer un chemin qu'un motif plus large exclurait sinon."
               }
             },
             "updateSubuser": {
@@ -1063,6 +4312,9 @@
               "toast": {
                 "deleted": "Sauvegarde supprimée."
               }
+            },
+            "viewMetadata": {
+              "title": "Métadonnées de la sauvegarde"
             }
           }
         },
@@ -1083,7 +4335,7 @@
             "updated": "Allocation mise à jour.",
             "removed": "Allocation supprimée.",
             "setPrimary": "Allocation définie comme primaire.",
-            "unsetPrimary": "Primarité de l'allocation retirée."
+            "unsetPrimary": "Statut primaire de l'allocation retiré."
           },
           "modal": {
             "editAllocation": {
@@ -1098,6 +4350,13 @@
         "startup": {
           "title": "Démarrage",
           "variables": "Variables",
+          "noVariables": "Aucune variable de démarrage trouvée pour ce serveur.",
+          "modal": {
+            "unsavedChanges": {
+              "title": "Changements non sauvegardés",
+              "content": "Vous avez des changements non sauvegardés dans vos variables de démarrage. Êtes-vous sûr de vouloir quitter cette page ? Si vous quittez, vos changements seront perdus."
+            }
+          },
           "dockerImageDescription": "L'image Docker utilisée pour lancer ce serveur. Elle peut être changée pour utiliser une autre image.",
           "dockerImageDescriptionCustom": "L'image Docker utilisée pour lancer ce serveur. Elle a été définie par un administrateur et ne peut pas être changée.",
           "toast": {
@@ -1108,6 +4367,14 @@
         },
         "settings": {
           "title": "Paramètres",
+          "debugInformation": {
+            "title": "Informations de débogage",
+            "form": {
+              "nodeName": "Nœud (UUID)",
+              "locationName": "Emplacement (UUID)",
+              "serverUuid": "UUID du serveur"
+            }
+          },
           "rename": {
             "title": "Renommer serveur",
             "toast": {
@@ -1152,7 +4419,10 @@
           }
         },
         "activity": {
-          "title": "Activité"
+          "title": "Activité",
+          "button": {
+            "clearUserFilter": "Effacer le filtre utilisateur"
+          }
         }
       }
     }


### PR DESCRIPTION
Bring fr.json to full parity with en.json (2302/2302 keys):
- complete admin pages (settings, nodes, servers, nests, users, roles, mounts, locations, oauth providers, backup configurations, egg configurations/repositories, database hosts, announcements, assets, extensions, activity)
- complete server pages (console, files, schedules, databases, backups, network, subusers, startup, settings, mounts, activity)
- complete auth, oobe, account and elements sections
- fix grammar/agreement errors and inconsistencies in existing strings
- conventions: vouvoiement, "passkey" -> "clé d'accès", "two-factor" -> "à deux facteurs"; Egg/Nest kept untranslated