### PR TITLE
Use junctions for Windows links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "include_dir",
  "indexmap 2.14.0",
  "infer",
+ "junction",
  "minijinja",
  "oauth2",
  "rand 0.10.1",
@@ -4950,6 +4951,16 @@ dependencies = [
  "signature 2.2.0",
  "simple_asn1",
  "zeroize",
+]
+
+[[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ hex = "0.4.3"
 zstd = "0.13.3"
 parking_lot = "0.12.5"
 tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
+junction = "2.0.0"
 
 # dev (for development)
 [profile.dev.package."*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ hex = "0.4.3"
 zstd = "0.13.3"
 parking_lot = "0.12.5"
 tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
-junction = "2.0.0"
 
 # dev (for development)
 [profile.dev.package."*"]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -68,4 +68,4 @@ rsa = "0.9.10"
 rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 
 [target.'cfg(windows)'.dependencies]
-junction = { workspace = true }
+junction = "2.0.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -66,3 +66,6 @@ cbc = "0.2.1"
 spki = "0.8.0"
 rsa = "0.9.10"
 rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
+
+[target.'cfg(windows)'.dependencies]
+junction = { workspace = true }

--- a/backend/src/commands/extensions/mod.rs
+++ b/backend/src/commands/extensions/mod.rs
@@ -36,7 +36,18 @@ fn symlink_dir(original: &Path, link: &Path) -> std::io::Result<()> {
 
 #[cfg(windows)]
 fn symlink_dir(original: &Path, link: &Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_dir(original, link)
+    // Windows symlinks require the SeCreateSymbolicLinkPrivilege privilege,
+    // std::os::windows::fs::symlink_dir(original, link);
+    // Use junctions instead to avoid this restriction.
+    //
+    // Junctions resolve relative targets differently from Unix symlinks, so
+    // rebase the target against the link's parent directory before creation.
+    let target = match link.parent() {
+        Some(parent) => parent.join(original),
+        None => original.to_path_buf(),
+    };
+
+    junction::create(target, link)
 }
 
 async fn remove_dir_or_symlink(path: &Path) -> std::io::Result<()> {

--- a/backend/src/commands/extensions/remove.rs
+++ b/backend/src/commands/extensions/remove.rs
@@ -91,7 +91,7 @@ impl shared::extensions::commands::CliCommand<RemoveArgs> for RemoveCommand {
                 }
 
                 let frontend_translations_path = Path::new("frontend/public/translations/en")
-                    .join(format!("{}.json", &args.package_name));
+                    .join(format!("{}.json", args.package_name));
                 let migrations_path =
                     Path::new("database/extension-migrations").join(&package_identifier);
 

--- a/bins/all-in-one/src/main.rs
+++ b/bins/all-in-one/src/main.rs
@@ -1,9 +1,6 @@
-use axum::{
-    ServiceExt,
-    body::Body,
-    extract::{ConnectInfo, Request},
-    middleware::Next,
-};
+use axum::{ServiceExt, extract::Request};
+#[cfg(unix)]
+use axum::{body::Body, extract::ConnectInfo, middleware::Next};
 use colored::Colorize;
 use shared::models::{
     ByUuid, CreatableModel, UpdatableModel, backup_configuration::BackupConfiguration,


### PR DESCRIPTION
Replace Windows directory symlinks with junctions to avoid requiring SeCreateSymbolicLinkPrivilege. The target path is rebased against the link parent before creation so extension directories resolve correctly.

Fixes #144