### PR TITLE
Reconnect when the websocket goes silent

### DIFF
--- a/frontend/src/plugins/Websocket.ts
+++ b/frontend/src/plugins/Websocket.ts
@@ -265,7 +265,8 @@ export class Websocket extends EventEmitter {
    * frames on its own and never surfaces them to JavaScript, so a connection
    * that a middlebox drops without a FIN stays readyState === OPEN here for as
    * long as TCP keeps retransmitting. This sends an application-level "ping"
-   * that wings replies to with "pong", giving us traffic we can actually see.
+   * that wings replies to with "pong", but only once the socket has gone quiet,
+   * so a busy connection carries no extra traffic.
    */
   private startHeartbeat(): void {
     this.stopHeartbeat();
@@ -299,13 +300,20 @@ export class Websocket extends EventEmitter {
       return;
     }
 
-    if (Date.now() - this.lastMessageAt > this.livenessTimeoutMs) {
+    const quietFor = Date.now() - this.lastMessageAt;
+
+    if (quietFor > this.livenessTimeoutMs) {
       console.warn('Websocket went silent; assuming the connection is dead and reconnecting.');
       this.forceReconnect();
       return;
     }
 
-    this.send('ping');
+    // Only probe when the socket has actually gone quiet. A running server
+    // pushes stats every second, so this stays silent in the common case and
+    // leaves the console's own ping/pong latency sampling alone.
+    if (quietFor >= this.heartbeatIntervalMs) {
+      this.send('ping');
+    }
   }
 
   /**

--- a/frontend/src/plugins/Websocket.ts
+++ b/frontend/src/plugins/Websocket.ts
@@ -260,14 +260,6 @@ export class Websocket extends EventEmitter {
     this.socket = null;
   }
 
-  /**
-   * Starts the liveness heartbeat. The browser answers protocol-level ping
-   * frames on its own and never surfaces them to JavaScript, so a connection
-   * that a middlebox drops without a FIN stays readyState === OPEN here for as
-   * long as TCP keeps retransmitting. This sends an application-level "ping"
-   * that wings replies to with "pong", but only once the socket has gone quiet,
-   * so a busy connection carries no extra traffic.
-   */
   private startHeartbeat(): void {
     this.stopHeartbeat();
 
@@ -308,19 +300,11 @@ export class Websocket extends EventEmitter {
       return;
     }
 
-    // Only probe when the socket has actually gone quiet. A running server
-    // pushes stats every second, so this stays silent in the common case and
-    // leaves the console's own ping/pong latency sampling alone.
     if (quietFor >= this.heartbeatIntervalMs) {
       this.send('ping');
     }
   }
 
-  /**
-   * Tears down a socket the browser still believes is open and schedules a
-   * reconnect. destroySocket() detaches the handlers first, so onclose will
-   * not fire and cannot queue a second reconnect.
-   */
   private forceReconnect(): void {
     this.destroySocket(4000, 'stale connection');
     this.state = SocketState.CLOSED;

--- a/frontend/src/plugins/Websocket.ts
+++ b/frontend/src/plugins/Websocket.ts
@@ -47,9 +47,15 @@ export class Websocket extends EventEmitter {
   private hadSuccessfulConnection = false;
   private nextRetryMs: number | null = null;
 
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private visibilityHandler: (() => void) | null = null;
+  private lastMessageAt = 0;
+
   private readonly minBackoff = 1000;
   private readonly maxBackoff = 20000;
   private readonly maxReconnectAttempts = Infinity;
+  private readonly heartbeatIntervalMs = 15000;
+  private readonly livenessTimeoutMs = 45000;
 
   /**
    * Returns the current connection state.
@@ -153,6 +159,8 @@ export class Websocket extends EventEmitter {
       this.clearReconnectTimer();
       this.state = SocketState.CONNECTED;
       this.hadSuccessfulConnection = true;
+      this.lastMessageAt = Date.now();
+      this.startHeartbeat();
 
       this.emit('SOCKET_ERROR_CLEAR');
       this.emit('SOCKET_OPEN');
@@ -160,6 +168,7 @@ export class Websocket extends EventEmitter {
     };
 
     this.socket.onmessage = (e: MessageEvent) => {
+      this.lastMessageAt = Date.now();
       try {
         this.emit('SOCKET_MESSAGE', e);
 
@@ -176,6 +185,7 @@ export class Websocket extends EventEmitter {
     };
 
     this.socket.onclose = (e: CloseEvent) => {
+      this.stopHeartbeat();
       const wasConnected = this.state === SocketState.CONNECTED;
       this.state = SocketState.CLOSED;
 
@@ -228,6 +238,8 @@ export class Websocket extends EventEmitter {
   }
 
   private destroySocket(code?: number, reason?: string): void {
+    this.stopHeartbeat();
+
     if (!this.socket) {
       return;
     }
@@ -246,6 +258,66 @@ export class Websocket extends EventEmitter {
     }
 
     this.socket = null;
+  }
+
+  /**
+   * Starts the liveness heartbeat. The browser answers protocol-level ping
+   * frames on its own and never surfaces them to JavaScript, so a connection
+   * that a middlebox drops without a FIN stays readyState === OPEN here for as
+   * long as TCP keeps retransmitting. This sends an application-level "ping"
+   * that wings replies to with "pong", giving us traffic we can actually see.
+   */
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+
+    this.heartbeatTimer = setInterval(() => this.checkLiveness(), this.heartbeatIntervalMs);
+
+    if (typeof document !== 'undefined') {
+      this.visibilityHandler = () => {
+        if (!document.hidden) {
+          this.checkLiveness();
+        }
+      };
+      document.addEventListener('visibilitychange', this.visibilityHandler);
+    }
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+
+    if (this.visibilityHandler !== null && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityHandler);
+      this.visibilityHandler = null;
+    }
+  }
+
+  private checkLiveness(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    if (Date.now() - this.lastMessageAt > this.livenessTimeoutMs) {
+      console.warn('Websocket went silent; assuming the connection is dead and reconnecting.');
+      this.forceReconnect();
+      return;
+    }
+
+    this.send('ping');
+  }
+
+  /**
+   * Tears down a socket the browser still believes is open and schedules a
+   * reconnect. destroySocket() detaches the handlers first, so onclose will
+   * not fire and cannot queue a second reconnect.
+   */
+  private forceReconnect(): void {
+    this.destroySocket(4000, 'stale connection');
+    this.state = SocketState.CLOSED;
+    this.emit('SOCKET_RECONNECT');
+    this.scheduleReconnect();
   }
 
   private scheduleReconnect(): void {

--- a/frontend/src/plugins/Websocket.ts
+++ b/frontend/src/plugins/Websocket.ts
@@ -50,11 +50,13 @@ export class Websocket extends EventEmitter {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private visibilityHandler: (() => void) | null = null;
   private lastMessageAt = 0;
+  private pingedSinceLastMessage = false;
 
   private readonly minBackoff = 1000;
   private readonly maxBackoff = 20000;
   private readonly maxReconnectAttempts = Infinity;
   private readonly heartbeatIntervalMs = 15000;
+  private readonly livenessCheckIntervalMs = 5000;
   private readonly livenessTimeoutMs = 45000;
 
   /**
@@ -160,6 +162,7 @@ export class Websocket extends EventEmitter {
       this.state = SocketState.CONNECTED;
       this.hadSuccessfulConnection = true;
       this.lastMessageAt = Date.now();
+      this.pingedSinceLastMessage = false;
       this.startHeartbeat();
 
       this.emit('SOCKET_ERROR_CLEAR');
@@ -263,7 +266,7 @@ export class Websocket extends EventEmitter {
   private startHeartbeat(): void {
     this.stopHeartbeat();
 
-    this.heartbeatTimer = setInterval(() => this.checkLiveness(), this.heartbeatIntervalMs);
+    this.heartbeatTimer = setInterval(() => this.checkLiveness(), this.livenessCheckIntervalMs);
 
     if (typeof document !== 'undefined') {
       this.visibilityHandler = () => {
@@ -294,13 +297,14 @@ export class Websocket extends EventEmitter {
 
     const quietFor = Date.now() - this.lastMessageAt;
 
-    if (quietFor > this.livenessTimeoutMs) {
+    if (quietFor >= this.livenessTimeoutMs) {
       console.warn('Websocket went silent; assuming the connection is dead and reconnecting.');
       this.forceReconnect();
       return;
     }
 
-    if (quietFor >= this.heartbeatIntervalMs) {
+    if (quietFor >= this.heartbeatIntervalMs && !this.pingedSinceLastMessage) {
+      this.pingedSinceLastMessage = true;
       this.send('ping');
     }
   }
@@ -310,6 +314,14 @@ export class Websocket extends EventEmitter {
     this.state = SocketState.CLOSED;
     this.emit('SOCKET_RECONNECT');
     this.scheduleReconnect();
+
+    this.emitError({
+      type: SocketErrorType.CONNECTION_LOST,
+      message: getTranslations().t('elements.serverWebsocket.error.connectionClosed', {}),
+      recoverable: true,
+      closeCode: 4000,
+      closeReason: 'stale connection',
+    });
   }
 
   private scheduleReconnect(): void {


### PR DESCRIPTION
The client has no way to notice that a connection died.

Wings sends protocol-level ping frames, but the browser answers those itself and never exposes them to JS. So when something in the middle drops the connection without a FIN, `readyState` stays `OPEN`, `onclose` never fires, and the reconnect logic in this class never runs. TCP does eventually give up, but that takes minutes, and until then the UI sits there looking connected.

This adds a liveness check on top of the `ping`/`pong` events the protocol already defines:

- every 15s, if the socket has been quiet for at least that long, send `ping`
- if nothing has arrived at all for 45s, tear the socket down and reconnect through the existing backoff
- re-check on `visibilitychange`, so a backgrounded tab notices as soon as it's focused again

The probe only fires when the socket is actually quiet. A running server pushes stats every second, so in the common case this sends nothing and stays clear of the ping/pong latency sampling in `Console.tsx`.

`destroySocket()` detaches the handlers before closing, so the forced teardown can't queue a second reconnect through `onclose`.

Checked against wings 1.1.0: it replies `pong` to the application-level `ping`, and re-emits `auth success` on re-auth, so the token refresh path is untouched.

I don't have a reproducer for the underlying drop — this is defensive. The behaviour it changes is the part that's clearly wrong: right now a dead socket is never detected at all.
