### PR TITLE
Recover the console when the websocket token expires

### DIFF
--- a/frontend/src/pages/server/WebsocketHandler.tsx
+++ b/frontend/src/pages/server/WebsocketHandler.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from '@/providers/TranslationProvider.tsx';
 import { useServerStore, useServerStoreApi } from '@/stores/server.ts';
 
 const MAX_TOKEN_REFRESH_FAILURES = 3;
+const TOKEN_REFRESH_TIMEOUT = 15000;
 
 export default function WebsocketHandler() {
   const serverStoreApi = useServerStoreApi();
@@ -43,21 +44,24 @@ export default function WebsocketHandler() {
     }
 
     if (tokenRefreshFailuresRef.current >= MAX_TOKEN_REFRESH_FAILURES) {
-      console.error(
-        `Websocket token refresh failed ${MAX_TOKEN_REFRESH_FAILURES} times consecutively. Aborting to prevent an infinite loop.`,
-      );
-      setSocketConnectionState(false);
-      setSocketError({
-        type: SocketErrorType.AUTH_FAILED,
-        message: t('elements.serverWebsocket.error.tokenRefreshLoop', {}),
-        recoverable: false,
-        reconnectAttempt: 0,
-        nextRetryMs: null,
-      });
+      // Wings does not close the socket when the token expires, it only revokes
+      // console permissions and keeps streaming stats, so giving up here leaves
+      // a connection that looks alive but never prints console output again.
+      // Rebuild it instead, which fetches a fresh token.
+      console.warn('Websocket token refresh kept failing; rebuilding the connection.');
+      tokenRefreshFailuresRef.current = 0;
+      rebuildSocket();
       return;
     }
 
     updatingTokenRef.current = true;
+
+    // This guard is otherwise only cleared in finally(), so a request that never
+    // settles would block every later refresh for the rest of the session.
+    const guard = setTimeout(() => {
+      updatingTokenRef.current = false;
+    }, TOKEN_REFRESH_TIMEOUT);
+
     getWebsocketToken(currentUuid)
       .then((data) => {
         if (socketRef.current === socket) {
@@ -69,8 +73,28 @@ export default function WebsocketHandler() {
         tokenRefreshFailuresRef.current += 1;
       })
       .finally(() => {
+        clearTimeout(guard);
         updatingTokenRef.current = false;
       });
+  };
+
+  const rebuildSocket = () => {
+    const currentUuid = uuidRef.current;
+
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+      setSocketInstance(null);
+      setSocketConnectionState(false);
+      setSocketError(null);
+    }
+
+    connectingRef.current = false;
+    updatingTokenRef.current = false;
+
+    if (currentUuid && !nodeMaintenanceEnabled) {
+      connect(currentUuid);
+    }
   };
 
   const connect = (uuid: string) => {


### PR DESCRIPTION
The server console stops printing after roughly ten minutes and only comes back on a page reload. CPU and memory keep updating the whole time, which is what makes it confusing to diagnose.

## What actually happens

Wings does not close the socket when the websocket JWT expires. It revokes `control.read-console` and keeps streaming everything else. Reproduced against wings 1.1.0 with a plain websocket client that deliberately never refreshed its token:

```
t+570s  token expiring
t+621s  jwt error: 'invalid token: token is expired'
t+630s  token expired
t+675s  daemon message: "You are missing the `control.read-console` permission"
```

After that point: zero `console output`, `stats` still arriving once a second. The socket stays open and looks perfectly healthy.

Confirmed from a browser too, counting frames by type. Between two samples taken a few seconds apart, with several commands sent in between:

```
console 150 -> 150     (frozen)
stats    31 -> 44      (still flowing)
```

So the client has to keep the token alive. It has everything it needs to: re-authenticating on the same socket restores console output on its own, no reconnect and no re-issued `send logs` required (verified separately over three expiry cycles).

## Why the client didn't recover

Two things in `updateToken`:

- `updatingTokenRef` is only cleared in `finally()`. A token request that never settles leaves it `true` forever, and every later refresh returns early at the guard. The token then expires and the console is dead for the rest of the session.
- Once `MAX_TOKEN_REFRESH_FAILURES` is reached it gives up permanently. Since wings keeps the socket open, nothing ever triggers a recovery.

## Change

- A timeout releases the in-flight guard so one stuck request can't wedge refreshes forever.
- Exhausting the retry budget rebuilds the socket instead of giving up, which fetches a fresh token through the normal `connect()` path.

After deploying this, a panel that previously died every ten minutes ran through a refresh cleanly:

```
04:53:58  auth success
05:02:58  token expiring
05:02:58  auth success
```

`jwt error` and `token expired` both stayed at zero, and console output kept flowing across the refresh.

Separately, it seems worth considering whether wings should close the socket, or at least surface something more actionable, instead of silently dropping console permissions on an otherwise live connection. Every client has to get this exactly right or it fails in a way that looks like a frontend rendering bug.
