### PR TITLE
Fix MySQL and MariaDB explorer compatibility

### DIFF
--- a/shared/src/models/server_database/explorer/mysql.rs
+++ b/shared/src/models/server_database/explorer/mysql.rs
@@ -123,7 +123,7 @@ const MYSQL_COLUMNS: &str = "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, COLUMN
     CAST(IS_NULLABLE = 'YES' AS SIGNED) AS nullable,
     CAST(COLUMN_KEY = 'PRI' AS SIGNED) AS primary_key,
     CAST(EXTRA LIKE '%auto_increment%' AS SIGNED) AS auto_increment,
-    CAST(EXTRA LIKE '%GENERATED%' AS SIGNED) AS generated,
+    CAST(EXTRA LIKE '%GENERATED%' AS SIGNED) AS is_generated,
     CAST(DATA_TYPE IN ('binary', 'varbinary', 'bit', 'geometry') OR DATA_TYPE LIKE '%blob' AS SIGNED)
         AS binary_data
     FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME, ORDINAL_POSITION";
@@ -132,7 +132,7 @@ const MYSQL_TABLE_COLUMNS: &str = "SELECT COLUMN_NAME, COLUMN_TYPE, COLUMN_DEFAU
     CAST(IS_NULLABLE = 'YES' AS SIGNED) AS nullable,
     CAST(COLUMN_KEY = 'PRI' AS SIGNED) AS primary_key,
     CAST(EXTRA LIKE '%auto_increment%' AS SIGNED) AS auto_increment,
-    CAST(EXTRA LIKE '%GENERATED%' AS SIGNED) AS generated,
+    CAST(EXTRA LIKE '%GENERATED%' AS SIGNED) AS is_generated,
     CAST(DATA_TYPE IN ('binary', 'varbinary', 'bit', 'geometry') OR DATA_TYPE LIKE '%blob' AS SIGNED)
         AS binary_data
     FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
@@ -149,7 +149,7 @@ fn mysql_column(row: &MySqlRow) -> Result<SchemaColumn, sqlx::Error> {
             .filter(|value| value != "NULL"),
         primary_key: row.try_get::<i64, _>("primary_key")? != 0,
         auto_increment: row.try_get::<i64, _>("auto_increment")? != 0,
-        generated: row.try_get::<i64, _>("generated")? != 0,
+        generated: row.try_get::<i64, _>("is_generated")? != 0,
         binary: row.try_get::<Option<i64>, _>("binary_data")?.unwrap_or(0) != 0,
     })
 }
@@ -204,12 +204,15 @@ impl ExplorerConnection for MysqlExplorer {
     }
 
     async fn set_read_only(&mut self, read_only: bool) -> Result<(), anyhow::Error> {
-        sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
-            "SET SESSION transaction_read_only = {}",
-            if read_only { 1 } else { 0 }
-        )))
-        .execute(&mut *self.connection)
-        .await?;
+        let statement = if read_only {
+            "SET SESSION TRANSACTION READ ONLY"
+        } else {
+            "SET SESSION TRANSACTION READ WRITE"
+        };
+
+        sqlx::raw_sql(statement)
+            .execute(&mut *self.connection)
+            .await?;
 
         Ok(())
     }

--- a/shared/src/models/server_database/explorer/mysql.rs
+++ b/shared/src/models/server_database/explorer/mysql.rs
@@ -123,7 +123,8 @@ const MYSQL_COLUMNS: &str = "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, COLUMN
     CAST(IS_NULLABLE = 'YES' AS SIGNED) AS nullable,
     CAST(COLUMN_KEY = 'PRI' AS SIGNED) AS primary_key,
     CAST(EXTRA LIKE '%auto_increment%' AS SIGNED) AS auto_increment,
-    CAST(EXTRA LIKE '%GENERATED%' AS SIGNED) AS is_generated,
+    CAST(EXTRA LIKE '%VIRTUAL GENERATED%' OR EXTRA LIKE '%STORED GENERATED%' AS SIGNED)
+        AS is_generated,
     CAST(DATA_TYPE IN ('binary', 'varbinary', 'bit', 'geometry') OR DATA_TYPE LIKE '%blob' AS SIGNED)
         AS binary_data
     FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME, ORDINAL_POSITION";
@@ -132,7 +133,8 @@ const MYSQL_TABLE_COLUMNS: &str = "SELECT COLUMN_NAME, COLUMN_TYPE, COLUMN_DEFAU
     CAST(IS_NULLABLE = 'YES' AS SIGNED) AS nullable,
     CAST(COLUMN_KEY = 'PRI' AS SIGNED) AS primary_key,
     CAST(EXTRA LIKE '%auto_increment%' AS SIGNED) AS auto_increment,
-    CAST(EXTRA LIKE '%GENERATED%' AS SIGNED) AS is_generated,
+    CAST(EXTRA LIKE '%VIRTUAL GENERATED%' OR EXTRA LIKE '%STORED GENERATED%' AS SIGNED)
+        AS is_generated,
     CAST(DATA_TYPE IN ('binary', 'varbinary', 'bit', 'geometry') OR DATA_TYPE LIKE '%blob' AS SIGNED)
         AS binary_data
     FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?


### PR DESCRIPTION
## What changed

- Avoid using GENERATED as an unquoted MySQL result alias because it is reserved.
- Detect only VIRTUAL GENERATED and STORED GENERATED columns, excluding MySQL default expressions marked DEFAULT_GENERATED.
- Use SET SESSION TRANSACTION READ ONLY/WRITE instead of the MySQL-specific transaction_read_only system variable.

## Why

The database explorer schema endpoint failed on MySQL 8 because generated is reserved, while MariaDB 10.11 does not expose the transaction_read_only variable. MySQL also marks default expressions such as DEFAULT CURRENT_TIMESTAMP as DEFAULT_GENERATED, which must remain editable.

## Impact

Restores database explorer schema loading for MySQL 8 and MariaDB 10.11 without changing the API response shape or treating generated defaults as generated columns.

## Validation

- cargo check -p shared
- rustfmt --edition 2024 --check shared/src/models/server_database/explorer/mysql.rs
- git diff checks
- MySQL 8 container: DEFAULT_GENERATED = 0; VIRTUAL/STORED GENERATED = 1
- MariaDB 10.11 container: ordinary default = 0; VIRTUAL/STORED GENERATED = 1