### PR TITLE
Add cron editor and next-run preview to system backup policies

### DIFF
--- a/frontend/public/translations/en.json
+++ b/frontend/public/translations/en.json
@@ -241,6 +241,17 @@
           "noMatches": "No matches",
           "exception": "Exception",
           "tooManyPatterns": "Matching is not counted automatically for more than {max} patterns."
+        },
+        "cronInput": {
+          "segments": {
+            "second": "Second",
+            "minute": "Minute",
+            "hour": "Hour",
+            "day": "Day",
+            "month": "Month",
+            "weekday": "Weekday"
+          },
+          "nextRun": "Next run is {timestamp}."
         }
       },
       "modal": {

--- a/frontend/src/elements/input/CronInput.tsx
+++ b/frontend/src/elements/input/CronInput.tsx
@@ -1,0 +1,141 @@
+import { CronExpressionParser } from 'cron-parser';
+import cronstrue from 'cronstrue/i18n';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import TextInput from '@/elements/input/TextInput.tsx';
+import Popover from '@/elements/Popover.tsx';
+import Stack from '@/elements/Stack.tsx';
+import Text from '@/elements/Text.tsx';
+import FormattedTimestamp from '@/elements/time/FormattedTimestamp.tsx';
+import { isValidCronExpression } from '@/lib/schemas/server/schedules.ts';
+import { useTranslations } from '@/providers/TranslationProvider.tsx';
+
+const CRON_SEGMENTS = ['second', 'minute', 'hour', 'day', 'month', 'weekday'] as const;
+
+interface CrontabEditorProps {
+  value: string;
+  setValue: (value: string) => void;
+}
+
+export function CrontabEditor({ value, setValue }: CrontabEditorProps) {
+  const { t } = useTranslations();
+  const [segments, setSegments] = useState(['0', '*', '*', '*', '*', '*']);
+
+  useEffect(() => {
+    const newSegments = value.split(' ');
+    if (segments.every((s, i) => newSegments[i] === s)) {
+      return;
+    }
+
+    for (let i = 0; i < CRON_SEGMENTS.length; i++) {
+      if (!newSegments[i]) {
+        newSegments[i] = i === 0 ? '0' : '*';
+      }
+    }
+
+    setSegments(newSegments);
+  }, [segments, value]);
+
+  const setSegment = (index: number, value: string) => {
+    const newSegments = [...segments.slice(0, index), value, ...segments.slice(index + 1)];
+    setSegments(newSegments);
+
+    setValue(newSegments.join(' '));
+  };
+
+  return (
+    <div className='grid grid-cols-3 gap-2 w-64'>
+      {CRON_SEGMENTS.map((segment, i) => (
+        <TextInput
+          key={segment}
+          label={t(`common.elements.cronInput.segments.${segment}`, {})}
+          placeholder={t(`common.elements.cronInput.segments.${segment}`, {})}
+          value={segments[i]}
+          className='flex-1'
+          onChange={(e) => setSegment(i, e.target.value)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface CronInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  error?: ReactNode;
+  label?: ReactNode;
+  description?: ReactNode;
+  required?: boolean;
+  placeholder?: string;
+  timezone?: string;
+}
+
+export default function CronInput({
+  value,
+  onChange,
+  onBlur,
+  error,
+  label,
+  description,
+  required,
+  placeholder,
+  timezone = 'UTC',
+}: CronInputProps) {
+  const { tReact, language } = useTranslations();
+
+  const cronValid = isValidCronExpression(value);
+
+  const cronDescription = useMemo(() => {
+    if (!cronValid) return null;
+
+    try {
+      return cronstrue.toString(value, { locale: language });
+    } catch {
+      return null;
+    }
+  }, [cronValid, value, language]);
+
+  const nextRun = useMemo(() => {
+    if (!cronValid) return null;
+
+    try {
+      return CronExpressionParser.parse(value, { tz: timezone }).next().toDate();
+    } catch {
+      return null;
+    }
+  }, [cronValid, value, timezone]);
+
+  return (
+    <Stack gap={4}>
+      <Popover>
+        <Popover.Target>
+          <TextInput
+            label={label}
+            description={description}
+            withAsterisk={required}
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onBlur={onBlur}
+            error={error}
+          />
+        </Popover.Target>
+        <Popover.Dropdown>
+          <CrontabEditor value={value} setValue={onChange} />
+        </Popover.Dropdown>
+      </Popover>
+
+      {(cronDescription || nextRun) && (
+        <Text c='dimmed' size='sm'>
+          {cronDescription && `${cronDescription} · `}
+          {nextRun &&
+            tReact('common.elements.cronInput.nextRun', {
+              timestamp: (
+                <FormattedTimestamp timestamp={nextRun} autoUpdate={false} precise tooltipClassName='inline-block' />
+              ),
+            })}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/frontend/src/lib/schemas/admin/systemBackupPolicies.ts
+++ b/frontend/src/lib/schemas/admin/systemBackupPolicies.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { nullableNumber, nullableString } from '@/lib/transformers.ts';
+import { isValidCronExpression } from '../server/schedules.ts';
 import { adminBackupConfigurationSchema } from './backupConfigurations.ts';
 import { adminLocationSchema } from './locations.ts';
 import { adminNodeSchema } from './nodes.ts';
@@ -37,6 +38,7 @@ export const adminSystemBackupPolicyUpdateSchema = z.lazy(() =>
     })
     .extend({
       backupConfigurationUuid: z.uuid().nullable(),
+      cron: z.string().refine(isValidCronExpression, { message: 'Invalid cron expression' }),
     }),
 );
 

--- a/frontend/src/pages/admin/systemBackupPolicies/SystemBackupPolicyCreateOrUpdate.tsx
+++ b/frontend/src/pages/admin/systemBackupPolicies/SystemBackupPolicyCreateOrUpdate.tsx
@@ -15,6 +15,7 @@ import { AdminCan } from '@/elements/Can.tsx';
 import AdminContentContainer from '@/elements/containers/AdminContentContainer.tsx';
 import { type FieldDef, FormEngine, useFormEngine } from '@/elements/form-engine/index.ts';
 import Group from '@/elements/Group.tsx';
+import CronInput from '@/elements/input/CronInput.tsx';
 import Switch from '@/elements/input/Switch.tsx';
 import ConfirmationModal from '@/elements/modals/ConfirmationModal.tsx';
 import Stack from '@/elements/Stack.tsx';
@@ -143,12 +144,24 @@ export default function SystemBackupPolicyCreateOrUpdate({
     },
     { type: 'textarea', name: 'description', label: t('common.form.description', {}), rows: 3, colSpan: 'full' },
     {
-      type: 'text',
+      type: 'custom',
       name: 'cron',
-      label: t('pages.admin.systemBackupPolicies.form.cron', {}),
-      description: t('pages.admin.systemBackupPolicies.form.cronDescription', {}),
-      required: true,
-      props: { placeholder: '0 0 0 * * *' },
+      render: (form) => {
+        const inputProps = form.getInputProps('cron');
+
+        return (
+          <CronInput
+            label={t('pages.admin.systemBackupPolicies.form.cron', {})}
+            description={t('pages.admin.systemBackupPolicies.form.cronDescription', {})}
+            required
+            placeholder='0 0 0 * * *'
+            value={form.values.cron}
+            onChange={inputProps.onChange}
+            onBlur={inputProps.onBlur}
+            error={inputProps.error}
+          />
+        );
+      },
     },
     {
       type: 'number',

--- a/frontend/src/pages/server/schedules/triggers/TriggerForm.tsx
+++ b/frontend/src/pages/server/schedules/triggers/TriggerForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { z } from 'zod';
 import getSchedules from '@/api/server/schedules/getSchedules.ts';
 import Group from '@/elements/Group.tsx';
+import { CrontabEditor } from '@/elements/input/CronInput.tsx';
 import NumberInput from '@/elements/input/NumberInput.tsx';
 import Select from '@/elements/input/Select.tsx';
 import SizeInput from '@/elements/input/SizeInput.tsx';
@@ -29,7 +30,6 @@ import { useTranslations } from '@/providers/TranslationProvider.tsx';
 import { useServerStore } from '@/stores/server.ts';
 import ScheduleDynamicParameterInput from '../ScheduleDynamicParameterInput.tsx';
 
-const CRON_SEGMENTS = ['Second', 'Minute', 'Hour', 'Day', 'Month', 'Weekday'] as const;
 const CRON_WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const;
 
 type SimpleSchedule =
@@ -102,52 +102,6 @@ function simpleScheduleToCron(schedule: SimpleSchedule): string {
     case 'monthly':
       return `0 ${schedule.minute} ${schedule.hour} ${schedule.day} * *`;
   }
-}
-
-interface CrontabEditorProps {
-  value: string;
-  setValue: (value: string) => void;
-}
-
-function CrontabEditor({ value, setValue }: CrontabEditorProps) {
-  const [segments, setSegments] = useState(['0', '*', '*', '*', '*', '*']);
-
-  useEffect(() => {
-    const newSegments = value.split(' ');
-    if (segments.every((s, i) => newSegments[i] === s)) {
-      return;
-    }
-
-    for (let i = 0; i < CRON_SEGMENTS.length; i++) {
-      if (!newSegments[i]) {
-        newSegments[i] = i === 0 ? '0' : '*';
-      }
-    }
-
-    setSegments(newSegments);
-  }, [segments, value]);
-
-  const setSegment = (index: number, value: string) => {
-    const newSegments = [...segments.slice(0, index), value, ...segments.slice(index + 1)];
-    setSegments(newSegments);
-
-    setValue(newSegments.join(' '));
-  };
-
-  return (
-    <div className='grid grid-cols-3 gap-2 w-64'>
-      {CRON_SEGMENTS.map((label, i) => (
-        <TextInput
-          key={label}
-          label={label}
-          placeholder={label}
-          value={segments[i]}
-          className='flex-1'
-          onChange={(e) => setSegment(i, e.target.value)}
-        />
-      ))}
-    </div>
-  );
 }
 
 interface TriggerFormProps {

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -119,6 +119,17 @@ const baseTranslations = defineTranslations({
           exception: 'Exception',
           tooManyPatterns: 'Matching is not counted automatically for more than {max} patterns.',
         },
+        cronInput: {
+          segments: {
+            second: 'Second',
+            minute: 'Minute',
+            hour: 'Hour',
+            day: 'Day',
+            month: 'Month',
+            weekday: 'Weekday',
+          },
+          nextRun: 'Next run is {timestamp}.',
+        },
       },
       modal: {
         duplicate: {


### PR DESCRIPTION
The system backup policy form renders its cron schedule as a plain text field, without the QoL the server schedule cron trigger already has. This brings both over:

- Clicking the cron field opens a popover with individual inputs for each segment (second, minute, hour, day, month, weekday), same editor the schedule trigger form uses.
- Below the field, a human-readable description of the expression plus the next run timestamp (computed in UTC, matching how policies are evaluated).
- The update schema now validates the cron expression the same way schedules do, so an invalid expression shows an inline error and blocks saving instead of failing on the backend.

Implementation: `CrontabEditor` moved out of `TriggerForm.tsx` into a new shared `elements/input/CronInput.tsx`, which wraps the text input, popover editor, and description/next-run line. The policy form uses it via a form-engine `custom` field. Segment labels are now translatable (`common.elements.cronInput.*`); English strings unchanged. The schedule trigger form imports the shared editor and behaves exactly as before.

Tested: `pnpm typecheck`, `biome check`, and `pnpm build` all pass.
